### PR TITLE
chore: Use 4 spaces instead of 2

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -3,5 +3,5 @@
   "trailingComma": "all",
   "singleQuote": true,
   "printWidth": 120,
-  "tabWidth": 2
+  "tabWidth": 4
 }

--- a/examples/map/forward-message/index.js
+++ b/examples/map/forward-message/index.js
@@ -1,19 +1,19 @@
 import { map } from 'numaflow';
 
 const udfMapper = {
-  drop: false,
+    drop: false,
 
-  async map(keys, datum) {
-    const data = JSON.stringify(datum);
-    console.log(`Running user-map function: keys=${keys} datum=${data}`);
-    const msg = {
-      value: Buffer.from('value-from-map'),
-      keys: ['test-key1', 'test-key2'],
-    };
-    const result = this.drop ? msg : map.messageToDrop();
-    this.drop = !this.drop;
-    return [result];
-  },
+    async map(keys, datum) {
+        const data = JSON.stringify(datum);
+        console.log(`Running user-map function: keys=${keys} datum=${data}`);
+        const msg = {
+            value: Buffer.from('value-from-map'),
+            keys: ['test-key1', 'test-key2'],
+        };
+        const result = this.drop ? msg : map.messageToDrop();
+        this.drop = !this.drop;
+        return [result];
+    },
 };
 
 map.createServer(udfMapper).start();

--- a/examples/sink/fallback/index.js
+++ b/examples/sink/fallback/index.js
@@ -1,16 +1,16 @@
 import { sink } from 'numaflow';
 
 const fbSink = {
-  async sink(datumStream) {
-    let responses = [];
-    for (const datum of datumStream) {
-      const response = {
-        id: datum.id,
-        status: 'FALLBACK',
-      };
-      responses.push(response);
-    }
-    return responses;
-  },
+    async sink(datumStream) {
+        let responses = [];
+        for (const datum of datumStream) {
+            const response = {
+                id: datum.id,
+                status: 'FALLBACK',
+            };
+            responses.push(response);
+        }
+        return responses;
+    },
 };
 sink.createServer(fbSink).start();

--- a/examples/sink/log/index.js
+++ b/examples/sink/log/index.js
@@ -1,19 +1,19 @@
 import { sink } from 'numaflow';
 
 const logSink = {
-  async sink(datumStream) {
-    let responses = [];
+    async sink(datumStream) {
+        let responses = [];
 
-    for (const datum of datumStream) {
-      console.log('User defined Sink: ', datum.id);
-      const response = {
-        id: datum.id,
-        success: true,
-      };
-      responses.push(response);
-    }
-    return responses;
-  },
+        for (const datum of datumStream) {
+            console.log('User defined Sink: ', datum.id);
+            const response = {
+                id: datum.id,
+                success: true,
+            };
+            responses.push(response);
+        }
+        return responses;
+    },
 };
 
 sink.createServer(logSink).start();

--- a/package.json
+++ b/package.json
@@ -9,15 +9,14 @@
     "proto"
   ],
   "scripts": {
-    "codegen-sink": "proto-loader-gen-types --longs=String --enums=String --defaults --oneofs --grpcLib=@grpc/grpc-js --importFileExtension='.ts' --outDir=./src/sink/proto/ proto/sink.proto",
-    "codegen-source": "proto-loader-gen-types --longs=String --enums=String --defaults --oneofs --grpcLib=@grpc/grpc-js --importFileExtension='.ts' --outDir=./src/source/proto/ proto/source.proto",
-    "codegen-sourcetransformer": "proto-loader-gen-types --longs=String --enums=String --defaults --oneofs --grpcLib=@grpc/grpc-js --importFileExtension='.ts' --outDir=./src/sourcetransformer/proto/ proto/sourcetransformer.proto",
-    "codegen-map": "proto-loader-gen-types --longs=String --enums=String --defaults --oneofs --grpcLib=@grpc/grpc-js --importFileExtension='.ts' --outDir=./src/map/proto/ proto/map.proto",
+    "codegen-sink": "proto-loader-gen-types --longs=String --enums=String --defaults --oneofs --grpcLib=@grpc/grpc-js --importFileExtension='.ts' --includeComments --outDir=./src/sink/proto/ proto/sink.proto",
+    "codegen-source": "proto-loader-gen-types --longs=String --enums=String --defaults --oneofs --grpcLib=@grpc/grpc-js --importFileExtension='.ts' --includeComments --outDir=./src/source/proto/ proto/source.proto",
+    "codegen-sourcetransformer": "proto-loader-gen-types --longs=String --enums=String --defaults --oneofs --grpcLib=@grpc/grpc-js --importFileExtension='.ts' --includeComments --outDir=./src/sourcetransformer/proto/ proto/sourcetransformer.proto",
+    "codegen-map": "proto-loader-gen-types --longs=String --enums=String --defaults --oneofs --grpcLib=@grpc/grpc-js --importFileExtension='.ts' --includeComments --outDir=./src/map/proto/ proto/map.proto",
     "codegen": "npm run codegen-sink && npm run codegen-source && npm run codegen-sourcetransformer && npm run codegen-map",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
-    "test": "vitest --run",
-    "test:ci": "vitest --run --reporter verbose",
+    "test": "vitest --run --reporter verbose",
     "build": "rm -rf dist && npm run format && tsc"
   },
   "keywords": [],

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -4,51 +4,51 @@ import { ServerInfo } from './server.js';
 export type Protocol = 'uds' | 'tcp';
 
 export const Protocols = {
-  UDS: 'uds' as Protocol,
-  TCP: 'tcp' as Protocol,
+    UDS: 'uds' as Protocol,
+    TCP: 'tcp' as Protocol,
 };
 
 // ContainerType type and constants
 export type ContainerType =
-  | 'sourcer'
-  | 'sourcetransformer'
-  | 'sinker'
-  | 'mapper'
-  | 'accumulator'
-  | 'reducer'
-  | 'reducestreamer'
-  | 'sessionreducer'
-  | 'sideinput'
-  | 'fb-sinker'
-  | 'serving';
+    | 'sourcer'
+    | 'sourcetransformer'
+    | 'sinker'
+    | 'mapper'
+    | 'accumulator'
+    | 'reducer'
+    | 'reducestreamer'
+    | 'sessionreducer'
+    | 'sideinput'
+    | 'fb-sinker'
+    | 'serving';
 
 export const ContainerTypes = {
-  Sourcer: 'sourcer' as ContainerType,
-  Sourcetransformer: 'sourcetransformer' as ContainerType,
-  Sinker: 'sinker' as ContainerType,
-  Mapper: 'mapper' as ContainerType,
-  Accumulator: 'accumulator' as ContainerType,
-  Reducer: 'reducer' as ContainerType,
-  Reducestreamer: 'reducestreamer' as ContainerType,
-  Sessionreducer: 'sessionreducer' as ContainerType,
-  Sideinput: 'sideinput' as ContainerType,
-  Fbsinker: 'fb-sinker' as ContainerType,
-  Serving: 'serving' as ContainerType,
+    Sourcer: 'sourcer' as ContainerType,
+    Sourcetransformer: 'sourcetransformer' as ContainerType,
+    Sinker: 'sinker' as ContainerType,
+    Mapper: 'mapper' as ContainerType,
+    Accumulator: 'accumulator' as ContainerType,
+    Reducer: 'reducer' as ContainerType,
+    Reducestreamer: 'reducestreamer' as ContainerType,
+    Sessionreducer: 'sessionreducer' as ContainerType,
+    Sideinput: 'sideinput' as ContainerType,
+    Fbsinker: 'fb-sinker' as ContainerType,
+    Serving: 'serving' as ContainerType,
 };
 
 // MinimumNumaflowVersions is the minimum version of Numaflow required by the current SDK version
 export const MinimumNumaflowVersions: Record<ContainerType, string> = {
-  sourcer: '1.4.0-z',
-  sourcetransformer: '1.4.0-z',
-  sinker: '1.4.0-z',
-  mapper: '1.4.0-z',
-  reducestreamer: '1.4.0-z',
-  accumulator: '1.5.0-z',
-  reducer: '1.4.0-z',
-  sessionreducer: '1.4.0-z',
-  sideinput: '1.4.0-z',
-  'fb-sinker': '1.4.0-z',
-  serving: '1.5.0-z',
+    sourcer: '1.4.0-z',
+    sourcetransformer: '1.4.0-z',
+    sinker: '1.4.0-z',
+    mapper: '1.4.0-z',
+    reducestreamer: '1.4.0-z',
+    accumulator: '1.5.0-z',
+    reducer: '1.4.0-z',
+    sessionreducer: '1.4.0-z',
+    sideinput: '1.4.0-z',
+    'fb-sinker': '1.4.0-z',
+    serving: '1.5.0-z',
 };
 
 // Container constants
@@ -62,7 +62,7 @@ export const MSG_DROP_TAG = 'U+005C__DROP__';
 export const MAP_MODE_KEY = 'MAP_MODE';
 export type MapMode = 'unary-map' | 'stream-map' | 'batch-map';
 export const MapModes = {
-  UNARY_MAP: 'unary-map' as MapMode,
-  STREAM_MAP: 'stream-map' as MapMode,
-  BATCH_MAP: 'batch-map' as MapMode,
+    UNARY_MAP: 'unary-map' as MapMode,
+    STREAM_MAP: 'stream-map' as MapMode,
+    BATCH_MAP: 'batch-map' as MapMode,
 };

--- a/src/common/server.ts
+++ b/src/common/server.ts
@@ -7,55 +7,55 @@ import { Protocol, Protocols } from './constants.js';
  * and the user-defined source running in separate containers.
  */
 type ServerOpts = {
-  /**
-   * Configures the maximum size (in bytes) for messages that the gRPC server can send or receive.
-   * This setting determines the upper limit for the size of messages exchanged during communication.
-   * By default, this value is set to 64 MiB.
-   */
-  grpcMaxMessageSizeBytes?: number;
+    /**
+     * Configures the maximum size (in bytes) for messages that the gRPC server can send or receive.
+     * This setting determines the upper limit for the size of messages exchanged during communication.
+     * By default, this value is set to 64 MiB.
+     */
+    grpcMaxMessageSizeBytes?: number;
 };
 
 type ServerInfo = {
-  protocol: Protocol;
-  language: string;
-  minimum_numaflow_version?: string;
-  version: string;
-  metadata?: Record<string, string> | null;
+    protocol: Protocol;
+    language: string;
+    minimum_numaflow_version?: string;
+    version: string;
+    metadata?: Record<string, string> | null;
 };
 
 export const DEFAULT_SERVER_INFO: ServerInfo = {
-  protocol: Protocols.UDS,
-  language: 'go',
-  version: 'v0.9.0',
+    protocol: Protocols.UDS,
+    language: 'go',
+    version: 'v0.9.0',
 };
 export const SERVER_INFO_FILE_END = 'U+005C__END__';
 export const DEFAULT_MAX_MESSAGE_SIZE = 1024 * 1024 * 64; // 64MiB
 
 function prepareServer(serverInfo: ServerInfo, serverInfoFilePath: string, socketAddress: string): void {
-  try {
-    // write server info to file
-    const serverInfoContent = JSON.stringify(serverInfo);
-    // check if directory exists
-    const infoDir = path.dirname(serverInfoFilePath);
-    if (!fs.existsSync(infoDir)) {
-      fs.mkdirSync(infoDir, { recursive: true });
-      console.log(`Created directory: ${infoDir}`);
+    try {
+        // write server info to file
+        const serverInfoContent = JSON.stringify(serverInfo);
+        // check if directory exists
+        const infoDir = path.dirname(serverInfoFilePath);
+        if (!fs.existsSync(infoDir)) {
+            fs.mkdirSync(infoDir, { recursive: true });
+            console.log(`Created directory: ${infoDir}`);
+        }
+        fs.writeFileSync(serverInfoFilePath, serverInfoContent + SERVER_INFO_FILE_END);
+        console.log(`Server info file written successfully to ${serverInfoFilePath}`);
+        //
+        if (fs.existsSync(socketAddress)) {
+            console.log(`Socket file ${socketAddress} already exists. Deleting it...`);
+            fs.unlinkSync(socketAddress);
+        }
+    } catch (err: any) {
+        console.error('FATAL: Failed to write server info file:', err.message);
+        process.exit(1);
     }
-    fs.writeFileSync(serverInfoFilePath, serverInfoContent + SERVER_INFO_FILE_END);
-    console.log(`Server info file written successfully to ${serverInfoFilePath}`);
-    //
-    if (fs.existsSync(socketAddress)) {
-      console.log(`Socket file ${socketAddress} already exists. Deleting it...`);
-      fs.unlinkSync(socketAddress);
-    }
-  } catch (err: any) {
-    console.error('FATAL: Failed to write server info file:', err.message);
-    process.exit(1);
-  }
 }
 
 function parseServerOptions(opts: ServerOpts = {}): ServerOpts {
-  const grpcMessageSizeBytes = Math.max(opts.grpcMaxMessageSizeBytes ?? DEFAULT_MAX_MESSAGE_SIZE, 512);
-  return { grpcMaxMessageSizeBytes: grpcMessageSizeBytes };
+    const grpcMessageSizeBytes = Math.max(opts.grpcMaxMessageSizeBytes ?? DEFAULT_MAX_MESSAGE_SIZE, 512);
+    return { grpcMaxMessageSizeBytes: grpcMessageSizeBytes };
 }
 export { prepareServer, parseServerOptions, ServerInfo, ServerOpts };

--- a/src/map/index.ts
+++ b/src/map/index.ts
@@ -12,29 +12,29 @@ import { DEFAULT_SERVER_INFO, parseServerOptions, prepareServer, ServerInfo, Ser
 import { ContainerTypes, MAP_MODE_KEY, MapModes, MinimumNumaflowVersions, MSG_DROP_TAG } from '../common/constants.js';
 
 const Paths = {
-  SOCKET_PATH: '/var/run/numaflow/map.sock',
-  SERVER_INFO_FILE_PATH: '/var/run/numaflow/mapper-server-info',
+    SOCKET_PATH: '/var/run/numaflow/map.sock',
+    SERVER_INFO_FILE_PATH: '/var/run/numaflow/mapper-server-info',
 };
 
 interface Datum {
-  value: Buffer;
-  eventTime: Date;
-  watermark: Date;
-  headers: Map<String, String>;
+    value: Buffer;
+    eventTime: Date;
+    watermark: Date;
+    headers: Map<String, String>;
 }
 
 type Message = {
-  value?: Buffer;
-  keys?: string[];
-  tags?: string[];
+    value?: Buffer;
+    keys?: string[];
+    tags?: string[];
 };
 
 export function messageToDrop(): Message {
-  return { tags: [MSG_DROP_TAG] };
+    return { tags: [MSG_DROP_TAG] };
 }
 
 interface Mapper {
-  map(keys: string[], datum: Datum): Promise<Message[]>;
+    map(keys: string[], datum: Datum): Promise<Message[]>;
 }
 
 // Resolve the current directory
@@ -42,153 +42,153 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 function createDatumFromRequest(request: MapRequest): Datum {
-  let buf = request.request?.value ?? '';
-  let payload: Buffer;
-  if (typeof buf === 'string') {
-    payload = Buffer.from(buf);
-  } else {
-    payload = Buffer.from(buf);
-  }
-
-  let et = request.request?.eventTime ?? new Date();
-  let eventTimeResponse: Date;
-  if (et instanceof Date) {
-    eventTimeResponse = et;
-  } else {
-    // FIXME: handle nanoseconds field in Timestamp
-    let seconds: number;
-    if (typeof et.seconds === 'string') {
-      seconds = parseInt(et.seconds, 10);
-    } else if (typeof et.seconds === 'object' && 'toNumber' in et.seconds) {
-      seconds = et.seconds.toNumber();
+    let buf = request.request?.value ?? '';
+    let payload: Buffer;
+    if (typeof buf === 'string') {
+        payload = Buffer.from(buf);
     } else {
-      seconds = et.seconds as number;
+        payload = Buffer.from(buf);
     }
-    eventTimeResponse = new Date(seconds * 1000);
-  }
 
-  let wt = request.request?.watermark ?? new Date();
-  let watermarkResponse: Date;
-  if (wt instanceof Date) {
-    watermarkResponse = wt;
-  } else {
-    // FIXME: handle nanoseconds field in Timestamp
-    let seconds: number;
-    if (typeof wt.seconds === 'string') {
-      seconds = parseInt(wt.seconds, 10);
-    } else if (typeof wt.seconds === 'object' && 'toNumber' in wt.seconds) {
-      seconds = wt.seconds.toNumber();
+    let et = request.request?.eventTime ?? new Date();
+    let eventTimeResponse: Date;
+    if (et instanceof Date) {
+        eventTimeResponse = et;
     } else {
-      seconds = wt.seconds as number;
+        // FIXME: handle nanoseconds field in Timestamp
+        let seconds: number;
+        if (typeof et.seconds === 'string') {
+            seconds = parseInt(et.seconds, 10);
+        } else if (typeof et.seconds === 'object' && 'toNumber' in et.seconds) {
+            seconds = et.seconds.toNumber();
+        } else {
+            seconds = et.seconds as number;
+        }
+        eventTimeResponse = new Date(seconds * 1000);
     }
-    watermarkResponse = new Date(seconds * 1000);
-  }
 
-  const headersObj = request.request?.headers ?? {};
-  const headersMap = new Map<String, String>();
+    let wt = request.request?.watermark ?? new Date();
+    let watermarkResponse: Date;
+    if (wt instanceof Date) {
+        watermarkResponse = wt;
+    } else {
+        // FIXME: handle nanoseconds field in Timestamp
+        let seconds: number;
+        if (typeof wt.seconds === 'string') {
+            seconds = parseInt(wt.seconds, 10);
+        } else if (typeof wt.seconds === 'object' && 'toNumber' in wt.seconds) {
+            seconds = wt.seconds.toNumber();
+        } else {
+            seconds = wt.seconds as number;
+        }
+        watermarkResponse = new Date(seconds * 1000);
+    }
 
-  for (const [key, value] of Object.entries(headersObj)) {
-    headersMap.set(key, value);
-  }
+    const headersObj = request.request?.headers ?? {};
+    const headersMap = new Map<String, String>();
 
-  return {
-    value: payload,
-    eventTime: eventTimeResponse,
-    watermark: watermarkResponse,
-    headers: headersMap,
-  };
+    for (const [key, value] of Object.entries(headersObj)) {
+        headersMap.set(key, value);
+    }
+
+    return {
+        value: payload,
+        eventTime: eventTimeResponse,
+        watermark: watermarkResponse,
+        headers: headersMap,
+    };
 }
 
 class MapService {
-  constructor(
-    private mapper: Mapper,
-    private opts: ServerOpts,
-  ) {}
+    constructor(
+        private mapper: Mapper,
+        private opts: ServerOpts,
+    ) {}
 
-  start(this: MapService) {
-    const serverInfo: ServerInfo = {
-      ...DEFAULT_SERVER_INFO,
-      minimum_numaflow_version: MinimumNumaflowVersions[ContainerTypes.Mapper],
-      metadata: { MAP_MODE_KEY: MapModes.UNARY_MAP },
-    };
-    prepareServer(serverInfo, Paths.SERVER_INFO_FILE_PATH, Paths.SOCKET_PATH);
-
-    const mapServer: MapHandlers = {
-      IsReady: this.isReady.bind(this),
-      MapFn: this.mapFn.bind(this),
-    };
-
-    const packageDef = protoLoader.loadSync(path.join(__dirname, '../../proto/map.proto'), {});
-    const proto = grpc.loadPackageDefinition(packageDef) as unknown as ProtoGrpcType;
-
-    const server = new grpc.Server({
-      'grpc.max_send_message_length': this.opts.grpcMaxMessageSizeBytes,
-      'grpc.max_receive_message_length': this.opts.grpcMaxMessageSizeBytes,
-    });
-    server.addService(proto.map.v1.Map.service, mapServer);
-    server.bindAsync(`unix://${Paths.SOCKET_PATH}`, grpc.ServerCredentials.createInsecure(), (err) => {
-      if (err) {
-        console.error('Failed to bind server:', err.message);
-        return;
-      }
-      console.log('Server bound successfully. Starting server...');
-    });
-  }
-
-  isReady(
-    this: MapService,
-    _call: grpc.ServerUnaryCall<Empty, ReadyResponse>,
-    callback: grpc.sendUnaryData<ReadyResponse>,
-  ) {
-    console.log(`Received isReady request`);
-    return callback(null, { ready: true });
-  }
-
-  private mapFn(this: MapService, call: grpc.ServerDuplexStream<MapRequest, MapResponse>) {
-    console.log('Map Fn called');
-    let handshakeDone = false;
-    call.on('data', async (request: MapRequest) => {
-      if (!handshakeDone) {
-        if (!request.handshake?.sot) {
-          console.error('Expected handshake message');
-        }
-        handshakeDone = true;
-        call.write({ handshake: { sot: true } });
-        console.log('Handshake completed');
-        return;
-      }
-      if (request.request) {
-        const keys = request.request.keys ?? [];
-        const datum = createDatumFromRequest(request);
-        const mappedValues = await this.mapper.map(keys, datum);
-        if (mappedValues.length === 0) {
-          // FIXME: Handle this
-          console.error(`Map response can not be empty. message_id=${request.id}`);
-        }
-        const response: MapResponse = {
-          id: request.id,
-          results: [],
+    start(this: MapService) {
+        const serverInfo: ServerInfo = {
+            ...DEFAULT_SERVER_INFO,
+            minimum_numaflow_version: MinimumNumaflowVersions[ContainerTypes.Mapper],
+            metadata: { MAP_MODE_KEY: MapModes.UNARY_MAP },
         };
-        for (const msg of mappedValues) {
-          response.results?.push({
-            ...msg,
-          });
-        }
-        call.write(response);
-        return;
-      }
-      console.log(`Invalid Source request: ${JSON.stringify(request, null, 2)}`);
-      throw { message: `invalid request: ${request}` };
-    });
+        prepareServer(serverInfo, Paths.SERVER_INFO_FILE_PATH, Paths.SOCKET_PATH);
 
-    call.on('end', () => {
-      console.log('Stream ended');
-      call.end(); // End the stream
-    });
-  }
+        const mapServer: MapHandlers = {
+            IsReady: this.isReady.bind(this),
+            MapFn: this.mapFn.bind(this),
+        };
+
+        const packageDef = protoLoader.loadSync(path.join(__dirname, '../../proto/map.proto'), {});
+        const proto = grpc.loadPackageDefinition(packageDef) as unknown as ProtoGrpcType;
+
+        const server = new grpc.Server({
+            'grpc.max_send_message_length': this.opts.grpcMaxMessageSizeBytes,
+            'grpc.max_receive_message_length': this.opts.grpcMaxMessageSizeBytes,
+        });
+        server.addService(proto.map.v1.Map.service, mapServer);
+        server.bindAsync(`unix://${Paths.SOCKET_PATH}`, grpc.ServerCredentials.createInsecure(), (err) => {
+            if (err) {
+                console.error('Failed to bind server:', err.message);
+                return;
+            }
+            console.log('Server bound successfully. Starting server...');
+        });
+    }
+
+    isReady(
+        this: MapService,
+        _call: grpc.ServerUnaryCall<Empty, ReadyResponse>,
+        callback: grpc.sendUnaryData<ReadyResponse>,
+    ) {
+        console.log(`Received isReady request`);
+        return callback(null, { ready: true });
+    }
+
+    private mapFn(this: MapService, call: grpc.ServerDuplexStream<MapRequest, MapResponse>) {
+        console.log('Map Fn called');
+        let handshakeDone = false;
+        call.on('data', async (request: MapRequest) => {
+            if (!handshakeDone) {
+                if (!request.handshake?.sot) {
+                    console.error('Expected handshake message');
+                }
+                handshakeDone = true;
+                call.write({ handshake: { sot: true } });
+                console.log('Handshake completed');
+                return;
+            }
+            if (request.request) {
+                const keys = request.request.keys ?? [];
+                const datum = createDatumFromRequest(request);
+                const mappedValues = await this.mapper.map(keys, datum);
+                if (mappedValues.length === 0) {
+                    // FIXME: Handle this
+                    console.error(`Map response can not be empty. message_id=${request.id}`);
+                }
+                const response: MapResponse = {
+                    id: request.id,
+                    results: [],
+                };
+                for (const msg of mappedValues) {
+                    response.results?.push({
+                        ...msg,
+                    });
+                }
+                call.write(response);
+                return;
+            }
+            console.log(`Invalid Source request: ${JSON.stringify(request, null, 2)}`);
+            throw { message: `invalid request: ${request}` };
+        });
+
+        call.on('end', () => {
+            console.log('Stream ended');
+            call.end(); // End the stream
+        });
+    }
 }
 
 export function createServer(mapper: Mapper, options?: ServerOpts): MapService {
-  const opts = parseServerOptions(options);
-  return new MapService(mapper, opts);
+    const opts = parseServerOptions(options);
+    return new MapService(mapper, opts);
 }

--- a/src/map/proto/google/protobuf/Empty.ts
+++ b/src/map/proto/google/protobuf/Empty.ts
@@ -1,5 +1,8 @@
 // Original file: null
 
-export interface Empty {}
 
-export interface Empty__Output {}
+export interface Empty {
+}
+
+export interface Empty__Output {
+}

--- a/src/map/proto/google/protobuf/Timestamp.ts
+++ b/src/map/proto/google/protobuf/Timestamp.ts
@@ -3,11 +3,11 @@
 import type { Long } from '@grpc/proto-loader';
 
 export interface Timestamp {
-  seconds?: number | string | Long;
-  nanos?: number;
+  'seconds'?: (number | string | Long);
+  'nanos'?: (number);
 }
 
 export interface Timestamp__Output {
-  seconds: string;
-  nanos: number;
+  'seconds': (string);
+  'nanos': (number);
 }

--- a/src/map/proto/map.ts
+++ b/src/map/proto/map.ts
@@ -4,26 +4,25 @@ import type { MessageTypeDefinition } from '@grpc/proto-loader';
 import type { MapClient as _map_v1_MapClient, MapDefinition as _map_v1_MapDefinition } from './map/v1/Map.ts';
 
 type SubtypeConstructor<Constructor extends new (...args: any) => any, Subtype> = {
-  new (...args: ConstructorParameters<Constructor>): Subtype;
+  new(...args: ConstructorParameters<Constructor>): Subtype;
 };
 
 export interface ProtoGrpcType {
   google: {
     protobuf: {
-      Empty: MessageTypeDefinition;
-      Timestamp: MessageTypeDefinition;
-    };
-  };
+      Empty: MessageTypeDefinition
+      Timestamp: MessageTypeDefinition
+    }
+  }
   map: {
     v1: {
-      Handshake: MessageTypeDefinition;
-      Map: SubtypeConstructor<typeof grpc.Client, _map_v1_MapClient> & {
-        service: _map_v1_MapDefinition;
-      };
-      MapRequest: MessageTypeDefinition;
-      MapResponse: MessageTypeDefinition;
-      ReadyResponse: MessageTypeDefinition;
-      TransmissionStatus: MessageTypeDefinition;
-    };
-  };
+      Handshake: MessageTypeDefinition
+      Map: SubtypeConstructor<typeof grpc.Client, _map_v1_MapClient> & { service: _map_v1_MapDefinition }
+      MapRequest: MessageTypeDefinition
+      MapResponse: MessageTypeDefinition
+      ReadyResponse: MessageTypeDefinition
+      TransmissionStatus: MessageTypeDefinition
+    }
+  }
 }
+

--- a/src/map/proto/map/v1/Handshake.ts
+++ b/src/map/proto/map/v1/Handshake.ts
@@ -1,9 +1,22 @@
 // Original file: proto/map.proto
 
+
+/**
+ * Handshake message between client and server to indicate the start of transmission.
+ */
 export interface Handshake {
-  sot?: boolean;
+  /**
+   * Required field indicating the start of transmission.
+   */
+  'sot'?: (boolean);
 }
 
+/**
+ * Handshake message between client and server to indicate the start of transmission.
+ */
 export interface Handshake__Output {
-  sot: boolean;
+  /**
+   * Required field indicating the start of transmission.
+   */
+  'sot': (boolean);
 }

--- a/src/map/proto/map/v1/Map.ts
+++ b/src/map/proto/map/v1/Map.ts
@@ -1,95 +1,55 @@
 // Original file: proto/map.proto
 
-import type * as grpc from '@grpc/grpc-js';
-import type { MethodDefinition } from '@grpc/proto-loader';
-import type {
-  Empty as _google_protobuf_Empty,
-  Empty__Output as _google_protobuf_Empty__Output,
-} from '../../google/protobuf/Empty.ts';
-import type {
-  MapRequest as _map_v1_MapRequest,
-  MapRequest__Output as _map_v1_MapRequest__Output,
-} from '../../map/v1/MapRequest.ts';
-import type {
-  MapResponse as _map_v1_MapResponse,
-  MapResponse__Output as _map_v1_MapResponse__Output,
-} from '../../map/v1/MapResponse.ts';
-import type {
-  ReadyResponse as _map_v1_ReadyResponse,
-  ReadyResponse__Output as _map_v1_ReadyResponse__Output,
-} from '../../map/v1/ReadyResponse.ts';
+import type * as grpc from '@grpc/grpc-js'
+import type { MethodDefinition } from '@grpc/proto-loader'
+import type { Empty as _google_protobuf_Empty, Empty__Output as _google_protobuf_Empty__Output } from '../../google/protobuf/Empty.ts';
+import type { MapRequest as _map_v1_MapRequest, MapRequest__Output as _map_v1_MapRequest__Output } from '../../map/v1/MapRequest.ts';
+import type { MapResponse as _map_v1_MapResponse, MapResponse__Output as _map_v1_MapResponse__Output } from '../../map/v1/MapResponse.ts';
+import type { ReadyResponse as _map_v1_ReadyResponse, ReadyResponse__Output as _map_v1_ReadyResponse__Output } from '../../map/v1/ReadyResponse.ts';
 
 export interface MapClient extends grpc.Client {
-  IsReady(
-    argument: _google_protobuf_Empty,
-    metadata: grpc.Metadata,
-    options: grpc.CallOptions,
-    callback: grpc.requestCallback<_map_v1_ReadyResponse__Output>,
-  ): grpc.ClientUnaryCall;
-  IsReady(
-    argument: _google_protobuf_Empty,
-    metadata: grpc.Metadata,
-    callback: grpc.requestCallback<_map_v1_ReadyResponse__Output>,
-  ): grpc.ClientUnaryCall;
-  IsReady(
-    argument: _google_protobuf_Empty,
-    options: grpc.CallOptions,
-    callback: grpc.requestCallback<_map_v1_ReadyResponse__Output>,
-  ): grpc.ClientUnaryCall;
-  IsReady(
-    argument: _google_protobuf_Empty,
-    callback: grpc.requestCallback<_map_v1_ReadyResponse__Output>,
-  ): grpc.ClientUnaryCall;
-  isReady(
-    argument: _google_protobuf_Empty,
-    metadata: grpc.Metadata,
-    options: grpc.CallOptions,
-    callback: grpc.requestCallback<_map_v1_ReadyResponse__Output>,
-  ): grpc.ClientUnaryCall;
-  isReady(
-    argument: _google_protobuf_Empty,
-    metadata: grpc.Metadata,
-    callback: grpc.requestCallback<_map_v1_ReadyResponse__Output>,
-  ): grpc.ClientUnaryCall;
-  isReady(
-    argument: _google_protobuf_Empty,
-    options: grpc.CallOptions,
-    callback: grpc.requestCallback<_map_v1_ReadyResponse__Output>,
-  ): grpc.ClientUnaryCall;
-  isReady(
-    argument: _google_protobuf_Empty,
-    callback: grpc.requestCallback<_map_v1_ReadyResponse__Output>,
-  ): grpc.ClientUnaryCall;
-
-  MapFn(
-    metadata: grpc.Metadata,
-    options?: grpc.CallOptions,
-  ): grpc.ClientDuplexStream<_map_v1_MapRequest, _map_v1_MapResponse__Output>;
+  /**
+   * IsReady is the heartbeat endpoint for gRPC.
+   */
+  IsReady(argument: _google_protobuf_Empty, metadata: grpc.Metadata, options: grpc.CallOptions, callback: grpc.requestCallback<_map_v1_ReadyResponse__Output>): grpc.ClientUnaryCall;
+  IsReady(argument: _google_protobuf_Empty, metadata: grpc.Metadata, callback: grpc.requestCallback<_map_v1_ReadyResponse__Output>): grpc.ClientUnaryCall;
+  IsReady(argument: _google_protobuf_Empty, options: grpc.CallOptions, callback: grpc.requestCallback<_map_v1_ReadyResponse__Output>): grpc.ClientUnaryCall;
+  IsReady(argument: _google_protobuf_Empty, callback: grpc.requestCallback<_map_v1_ReadyResponse__Output>): grpc.ClientUnaryCall;
+  /**
+   * IsReady is the heartbeat endpoint for gRPC.
+   */
+  isReady(argument: _google_protobuf_Empty, metadata: grpc.Metadata, options: grpc.CallOptions, callback: grpc.requestCallback<_map_v1_ReadyResponse__Output>): grpc.ClientUnaryCall;
+  isReady(argument: _google_protobuf_Empty, metadata: grpc.Metadata, callback: grpc.requestCallback<_map_v1_ReadyResponse__Output>): grpc.ClientUnaryCall;
+  isReady(argument: _google_protobuf_Empty, options: grpc.CallOptions, callback: grpc.requestCallback<_map_v1_ReadyResponse__Output>): grpc.ClientUnaryCall;
+  isReady(argument: _google_protobuf_Empty, callback: grpc.requestCallback<_map_v1_ReadyResponse__Output>): grpc.ClientUnaryCall;
+  
+  /**
+   * MapFn applies a function to each map request element.
+   */
+  MapFn(metadata: grpc.Metadata, options?: grpc.CallOptions): grpc.ClientDuplexStream<_map_v1_MapRequest, _map_v1_MapResponse__Output>;
   MapFn(options?: grpc.CallOptions): grpc.ClientDuplexStream<_map_v1_MapRequest, _map_v1_MapResponse__Output>;
-  mapFn(
-    metadata: grpc.Metadata,
-    options?: grpc.CallOptions,
-  ): grpc.ClientDuplexStream<_map_v1_MapRequest, _map_v1_MapResponse__Output>;
+  /**
+   * MapFn applies a function to each map request element.
+   */
+  mapFn(metadata: grpc.Metadata, options?: grpc.CallOptions): grpc.ClientDuplexStream<_map_v1_MapRequest, _map_v1_MapResponse__Output>;
   mapFn(options?: grpc.CallOptions): grpc.ClientDuplexStream<_map_v1_MapRequest, _map_v1_MapResponse__Output>;
+  
 }
 
 export interface MapHandlers extends grpc.UntypedServiceImplementation {
+  /**
+   * IsReady is the heartbeat endpoint for gRPC.
+   */
   IsReady: grpc.handleUnaryCall<_google_protobuf_Empty__Output, _map_v1_ReadyResponse>;
-
+  
+  /**
+   * MapFn applies a function to each map request element.
+   */
   MapFn: grpc.handleBidiStreamingCall<_map_v1_MapRequest__Output, _map_v1_MapResponse>;
+  
 }
 
 export interface MapDefinition extends grpc.ServiceDefinition {
-  IsReady: MethodDefinition<
-    _google_protobuf_Empty,
-    _map_v1_ReadyResponse,
-    _google_protobuf_Empty__Output,
-    _map_v1_ReadyResponse__Output
-  >;
-  MapFn: MethodDefinition<
-    _map_v1_MapRequest,
-    _map_v1_MapResponse,
-    _map_v1_MapRequest__Output,
-    _map_v1_MapResponse__Output
-  >;
+  IsReady: MethodDefinition<_google_protobuf_Empty, _map_v1_ReadyResponse, _google_protobuf_Empty__Output, _map_v1_ReadyResponse__Output>
+  MapFn: MethodDefinition<_map_v1_MapRequest, _map_v1_MapResponse, _map_v1_MapRequest__Output, _map_v1_MapResponse__Output>
 }

--- a/src/map/proto/map/v1/MapRequest.ts
+++ b/src/map/proto/map/v1/MapRequest.ts
@@ -1,48 +1,51 @@
 // Original file: proto/map.proto
 
-import type {
-  Handshake as _map_v1_Handshake,
-  Handshake__Output as _map_v1_Handshake__Output,
-} from '../../map/v1/Handshake.ts';
-import type {
-  TransmissionStatus as _map_v1_TransmissionStatus,
-  TransmissionStatus__Output as _map_v1_TransmissionStatus__Output,
-} from '../../map/v1/TransmissionStatus.ts';
-import type {
-  Timestamp as _google_protobuf_Timestamp,
-  Timestamp__Output as _google_protobuf_Timestamp__Output,
-} from '../../google/protobuf/Timestamp.ts';
+import type { Handshake as _map_v1_Handshake, Handshake__Output as _map_v1_Handshake__Output } from '../../map/v1/Handshake.ts';
+import type { TransmissionStatus as _map_v1_TransmissionStatus, TransmissionStatus__Output as _map_v1_TransmissionStatus__Output } from '../../map/v1/TransmissionStatus.ts';
+import type { Timestamp as _google_protobuf_Timestamp, Timestamp__Output as _google_protobuf_Timestamp__Output } from '../../google/protobuf/Timestamp.ts';
 
 export interface _map_v1_MapRequest_Request {
-  keys?: string[];
-  value?: Buffer | Uint8Array | string;
-  eventTime?: _google_protobuf_Timestamp | null;
-  watermark?: _google_protobuf_Timestamp | null;
-  headers?: { [key: string]: string };
+  'keys'?: (string)[];
+  'value'?: (Buffer | Uint8Array | string);
+  'eventTime'?: (_google_protobuf_Timestamp | null);
+  'watermark'?: (_google_protobuf_Timestamp | null);
+  'headers'?: ({[key: string]: string});
 }
 
 export interface _map_v1_MapRequest_Request__Output {
-  keys: string[];
-  value: Buffer;
-  eventTime: _google_protobuf_Timestamp__Output | null;
-  watermark: _google_protobuf_Timestamp__Output | null;
-  headers: { [key: string]: string };
+  'keys': (string)[];
+  'value': (Buffer);
+  'eventTime': (_google_protobuf_Timestamp__Output | null);
+  'watermark': (_google_protobuf_Timestamp__Output | null);
+  'headers': ({[key: string]: string});
 }
 
+/**
+ * MapRequest represents a request element.
+ */
 export interface MapRequest {
-  request?: _map_v1_MapRequest_Request | null;
-  id?: string;
-  handshake?: _map_v1_Handshake | null;
-  status?: _map_v1_TransmissionStatus | null;
-  _handshake?: 'handshake';
-  _status?: 'status';
+  'request'?: (_map_v1_MapRequest_Request | null);
+  /**
+   * This ID is used to uniquely identify a map request
+   */
+  'id'?: (string);
+  'handshake'?: (_map_v1_Handshake | null);
+  'status'?: (_map_v1_TransmissionStatus | null);
+  '_handshake'?: "handshake";
+  '_status'?: "status";
 }
 
+/**
+ * MapRequest represents a request element.
+ */
 export interface MapRequest__Output {
-  request: _map_v1_MapRequest_Request__Output | null;
-  id: string;
-  handshake?: _map_v1_Handshake__Output | null;
-  status?: _map_v1_TransmissionStatus__Output | null;
-  _handshake?: 'handshake';
-  _status?: 'status';
+  'request': (_map_v1_MapRequest_Request__Output | null);
+  /**
+   * This ID is used to uniquely identify a map request
+   */
+  'id': (string);
+  'handshake'?: (_map_v1_Handshake__Output | null);
+  'status'?: (_map_v1_TransmissionStatus__Output | null);
+  '_handshake'?: "handshake";
+  '_status'?: "status";
 }

--- a/src/map/proto/map/v1/MapResponse.ts
+++ b/src/map/proto/map/v1/MapResponse.ts
@@ -1,40 +1,46 @@
 // Original file: proto/map.proto
 
-import type {
-  Handshake as _map_v1_Handshake,
-  Handshake__Output as _map_v1_Handshake__Output,
-} from '../../map/v1/Handshake.ts';
-import type {
-  TransmissionStatus as _map_v1_TransmissionStatus,
-  TransmissionStatus__Output as _map_v1_TransmissionStatus__Output,
-} from '../../map/v1/TransmissionStatus.ts';
+import type { Handshake as _map_v1_Handshake, Handshake__Output as _map_v1_Handshake__Output } from '../../map/v1/Handshake.ts';
+import type { TransmissionStatus as _map_v1_TransmissionStatus, TransmissionStatus__Output as _map_v1_TransmissionStatus__Output } from '../../map/v1/TransmissionStatus.ts';
 
 export interface _map_v1_MapResponse_Result {
-  keys?: string[];
-  value?: Buffer | Uint8Array | string;
-  tags?: string[];
+  'keys'?: (string)[];
+  'value'?: (Buffer | Uint8Array | string);
+  'tags'?: (string)[];
 }
 
 export interface _map_v1_MapResponse_Result__Output {
-  keys: string[];
-  value: Buffer;
-  tags: string[];
+  'keys': (string)[];
+  'value': (Buffer);
+  'tags': (string)[];
 }
 
+/**
+ * MapResponse represents a response element.
+ */
 export interface MapResponse {
-  results?: _map_v1_MapResponse_Result[];
-  id?: string;
-  handshake?: _map_v1_Handshake | null;
-  status?: _map_v1_TransmissionStatus | null;
-  _handshake?: 'handshake';
-  _status?: 'status';
+  'results'?: (_map_v1_MapResponse_Result)[];
+  /**
+   * This ID is used to refer the responses to the request it corresponds to.
+   */
+  'id'?: (string);
+  'handshake'?: (_map_v1_Handshake | null);
+  'status'?: (_map_v1_TransmissionStatus | null);
+  '_handshake'?: "handshake";
+  '_status'?: "status";
 }
 
+/**
+ * MapResponse represents a response element.
+ */
 export interface MapResponse__Output {
-  results: _map_v1_MapResponse_Result__Output[];
-  id: string;
-  handshake?: _map_v1_Handshake__Output | null;
-  status?: _map_v1_TransmissionStatus__Output | null;
-  _handshake?: 'handshake';
-  _status?: 'status';
+  'results': (_map_v1_MapResponse_Result__Output)[];
+  /**
+   * This ID is used to refer the responses to the request it corresponds to.
+   */
+  'id': (string);
+  'handshake'?: (_map_v1_Handshake__Output | null);
+  'status'?: (_map_v1_TransmissionStatus__Output | null);
+  '_handshake'?: "handshake";
+  '_status'?: "status";
 }

--- a/src/map/proto/map/v1/ReadyResponse.ts
+++ b/src/map/proto/map/v1/ReadyResponse.ts
@@ -1,9 +1,16 @@
 // Original file: proto/map.proto
 
+
+/**
+ * ReadyResponse is the health check result.
+ */
 export interface ReadyResponse {
-  ready?: boolean;
+  'ready'?: (boolean);
 }
 
+/**
+ * ReadyResponse is the health check result.
+ */
 export interface ReadyResponse__Output {
-  ready: boolean;
+  'ready': (boolean);
 }

--- a/src/map/proto/map/v1/TransmissionStatus.ts
+++ b/src/map/proto/map/v1/TransmissionStatus.ts
@@ -1,9 +1,16 @@
 // Original file: proto/map.proto
 
+
+/**
+ * Status message to indicate the status of the message.
+ */
 export interface TransmissionStatus {
-  eot?: boolean;
+  'eot'?: (boolean);
 }
 
+/**
+ * Status message to indicate the status of the message.
+ */
 export interface TransmissionStatus__Output {
-  eot: boolean;
+  'eot': (boolean);
 }

--- a/src/sink/index.test.ts
+++ b/src/sink/index.test.ts
@@ -4,15 +4,15 @@ import { Sinker } from './types.js';
 import { ServerOpts } from '../common/server.js';
 
 describe('createServer', () => {
-  it('should create a SinkerService instance', () => {
-    const mockSinker: Sinker = {
-      sink: vi.fn(),
-    };
-    const options: ServerOpts = {
-      grpcMaxMessageSizeBytes: 1024 * 1024,
-    };
+    it('should create a SinkerService instance', () => {
+        const mockSinker: Sinker = {
+            sink: vi.fn(),
+        };
+        const options: ServerOpts = {
+            grpcMaxMessageSizeBytes: 1024 * 1024,
+        };
 
-    const server = createServer(mockSinker, options);
-    expect(server).toBeDefined();
-  });
+        const server = createServer(mockSinker, options);
+        expect(server).toBeDefined();
+    });
 });

--- a/src/sink/index.ts
+++ b/src/sink/index.ts
@@ -4,6 +4,6 @@ import { ServerOpts } from '../common/server.js';
 import { parseServerOptions } from '../common/server.js';
 
 export function createServer(sinker: Sinker, options?: ServerOpts): SinkerService {
-  const opts = parseServerOptions(options);
-  return new SinkerService(sinker, opts);
+    const opts = parseServerOptions(options);
+    return new SinkerService(sinker, opts);
 }

--- a/src/sink/proto/google/protobuf/Empty.ts
+++ b/src/sink/proto/google/protobuf/Empty.ts
@@ -1,5 +1,8 @@
 // Original file: null
 
-export interface Empty {}
 
-export interface Empty__Output {}
+export interface Empty {
+}
+
+export interface Empty__Output {
+}

--- a/src/sink/proto/google/protobuf/Timestamp.ts
+++ b/src/sink/proto/google/protobuf/Timestamp.ts
@@ -3,11 +3,11 @@
 import type { Long } from '@grpc/proto-loader';
 
 export interface Timestamp {
-  seconds?: number | string | Long;
-  nanos?: number;
+  'seconds'?: (number | string | Long);
+  'nanos'?: (number);
 }
 
 export interface Timestamp__Output {
-  seconds: string;
-  nanos: number;
+  'seconds': (string);
+  'nanos': (number);
 }

--- a/src/sink/proto/sink.ts
+++ b/src/sink/proto/sink.ts
@@ -4,27 +4,26 @@ import type { EnumTypeDefinition, MessageTypeDefinition } from '@grpc/proto-load
 import type { SinkClient as _sink_v1_SinkClient, SinkDefinition as _sink_v1_SinkDefinition } from './sink/v1/Sink.ts';
 
 type SubtypeConstructor<Constructor extends new (...args: any) => any, Subtype> = {
-  new (...args: ConstructorParameters<Constructor>): Subtype;
+  new(...args: ConstructorParameters<Constructor>): Subtype;
 };
 
 export interface ProtoGrpcType {
   google: {
     protobuf: {
-      Empty: MessageTypeDefinition;
-      Timestamp: MessageTypeDefinition;
-    };
-  };
+      Empty: MessageTypeDefinition
+      Timestamp: MessageTypeDefinition
+    }
+  }
   sink: {
     v1: {
-      Handshake: MessageTypeDefinition;
-      ReadyResponse: MessageTypeDefinition;
-      Sink: SubtypeConstructor<typeof grpc.Client, _sink_v1_SinkClient> & {
-        service: _sink_v1_SinkDefinition;
-      };
-      SinkRequest: MessageTypeDefinition;
-      SinkResponse: MessageTypeDefinition;
-      Status: EnumTypeDefinition;
-      TransmissionStatus: MessageTypeDefinition;
-    };
-  };
+      Handshake: MessageTypeDefinition
+      ReadyResponse: MessageTypeDefinition
+      Sink: SubtypeConstructor<typeof grpc.Client, _sink_v1_SinkClient> & { service: _sink_v1_SinkDefinition }
+      SinkRequest: MessageTypeDefinition
+      SinkResponse: MessageTypeDefinition
+      Status: EnumTypeDefinition
+      TransmissionStatus: MessageTypeDefinition
+    }
+  }
 }
+

--- a/src/sink/proto/sink/v1/Handshake.ts
+++ b/src/sink/proto/sink/v1/Handshake.ts
@@ -1,9 +1,22 @@
 // Original file: proto/sink.proto
 
+
+/**
+ * Handshake message between client and server to indicate the start of transmission.
+ */
 export interface Handshake {
-  sot?: boolean;
+  /**
+   * Required field indicating the start of transmission.
+   */
+  'sot'?: (boolean);
 }
 
+/**
+ * Handshake message between client and server to indicate the start of transmission.
+ */
 export interface Handshake__Output {
-  sot: boolean;
+  /**
+   * Required field indicating the start of transmission.
+   */
+  'sot': (boolean);
 }

--- a/src/sink/proto/sink/v1/ReadyResponse.ts
+++ b/src/sink/proto/sink/v1/ReadyResponse.ts
@@ -1,9 +1,16 @@
 // Original file: proto/sink.proto
 
+
+/**
+ * ReadyResponse is the health check result.
+ */
 export interface ReadyResponse {
-  ready?: boolean;
+  'ready'?: (boolean);
 }
 
+/**
+ * ReadyResponse is the health check result.
+ */
 export interface ReadyResponse__Output {
-  ready: boolean;
+  'ready': (boolean);
 }

--- a/src/sink/proto/sink/v1/Sink.ts
+++ b/src/sink/proto/sink/v1/Sink.ts
@@ -1,95 +1,55 @@
 // Original file: proto/sink.proto
 
-import type * as grpc from '@grpc/grpc-js';
-import type { MethodDefinition } from '@grpc/proto-loader';
-import type {
-  Empty as _google_protobuf_Empty,
-  Empty__Output as _google_protobuf_Empty__Output,
-} from '../../google/protobuf/Empty.ts';
-import type {
-  ReadyResponse as _sink_v1_ReadyResponse,
-  ReadyResponse__Output as _sink_v1_ReadyResponse__Output,
-} from '../../sink/v1/ReadyResponse.ts';
-import type {
-  SinkRequest as _sink_v1_SinkRequest,
-  SinkRequest__Output as _sink_v1_SinkRequest__Output,
-} from '../../sink/v1/SinkRequest.ts';
-import type {
-  SinkResponse as _sink_v1_SinkResponse,
-  SinkResponse__Output as _sink_v1_SinkResponse__Output,
-} from '../../sink/v1/SinkResponse.ts';
+import type * as grpc from '@grpc/grpc-js'
+import type { MethodDefinition } from '@grpc/proto-loader'
+import type { Empty as _google_protobuf_Empty, Empty__Output as _google_protobuf_Empty__Output } from '../../google/protobuf/Empty.ts';
+import type { ReadyResponse as _sink_v1_ReadyResponse, ReadyResponse__Output as _sink_v1_ReadyResponse__Output } from '../../sink/v1/ReadyResponse.ts';
+import type { SinkRequest as _sink_v1_SinkRequest, SinkRequest__Output as _sink_v1_SinkRequest__Output } from '../../sink/v1/SinkRequest.ts';
+import type { SinkResponse as _sink_v1_SinkResponse, SinkResponse__Output as _sink_v1_SinkResponse__Output } from '../../sink/v1/SinkResponse.ts';
 
 export interface SinkClient extends grpc.Client {
-  IsReady(
-    argument: _google_protobuf_Empty,
-    metadata: grpc.Metadata,
-    options: grpc.CallOptions,
-    callback: grpc.requestCallback<_sink_v1_ReadyResponse__Output>,
-  ): grpc.ClientUnaryCall;
-  IsReady(
-    argument: _google_protobuf_Empty,
-    metadata: grpc.Metadata,
-    callback: grpc.requestCallback<_sink_v1_ReadyResponse__Output>,
-  ): grpc.ClientUnaryCall;
-  IsReady(
-    argument: _google_protobuf_Empty,
-    options: grpc.CallOptions,
-    callback: grpc.requestCallback<_sink_v1_ReadyResponse__Output>,
-  ): grpc.ClientUnaryCall;
-  IsReady(
-    argument: _google_protobuf_Empty,
-    callback: grpc.requestCallback<_sink_v1_ReadyResponse__Output>,
-  ): grpc.ClientUnaryCall;
-  isReady(
-    argument: _google_protobuf_Empty,
-    metadata: grpc.Metadata,
-    options: grpc.CallOptions,
-    callback: grpc.requestCallback<_sink_v1_ReadyResponse__Output>,
-  ): grpc.ClientUnaryCall;
-  isReady(
-    argument: _google_protobuf_Empty,
-    metadata: grpc.Metadata,
-    callback: grpc.requestCallback<_sink_v1_ReadyResponse__Output>,
-  ): grpc.ClientUnaryCall;
-  isReady(
-    argument: _google_protobuf_Empty,
-    options: grpc.CallOptions,
-    callback: grpc.requestCallback<_sink_v1_ReadyResponse__Output>,
-  ): grpc.ClientUnaryCall;
-  isReady(
-    argument: _google_protobuf_Empty,
-    callback: grpc.requestCallback<_sink_v1_ReadyResponse__Output>,
-  ): grpc.ClientUnaryCall;
-
-  SinkFn(
-    metadata: grpc.Metadata,
-    options?: grpc.CallOptions,
-  ): grpc.ClientDuplexStream<_sink_v1_SinkRequest, _sink_v1_SinkResponse__Output>;
+  /**
+   * IsReady is the heartbeat endpoint for gRPC.
+   */
+  IsReady(argument: _google_protobuf_Empty, metadata: grpc.Metadata, options: grpc.CallOptions, callback: grpc.requestCallback<_sink_v1_ReadyResponse__Output>): grpc.ClientUnaryCall;
+  IsReady(argument: _google_protobuf_Empty, metadata: grpc.Metadata, callback: grpc.requestCallback<_sink_v1_ReadyResponse__Output>): grpc.ClientUnaryCall;
+  IsReady(argument: _google_protobuf_Empty, options: grpc.CallOptions, callback: grpc.requestCallback<_sink_v1_ReadyResponse__Output>): grpc.ClientUnaryCall;
+  IsReady(argument: _google_protobuf_Empty, callback: grpc.requestCallback<_sink_v1_ReadyResponse__Output>): grpc.ClientUnaryCall;
+  /**
+   * IsReady is the heartbeat endpoint for gRPC.
+   */
+  isReady(argument: _google_protobuf_Empty, metadata: grpc.Metadata, options: grpc.CallOptions, callback: grpc.requestCallback<_sink_v1_ReadyResponse__Output>): grpc.ClientUnaryCall;
+  isReady(argument: _google_protobuf_Empty, metadata: grpc.Metadata, callback: grpc.requestCallback<_sink_v1_ReadyResponse__Output>): grpc.ClientUnaryCall;
+  isReady(argument: _google_protobuf_Empty, options: grpc.CallOptions, callback: grpc.requestCallback<_sink_v1_ReadyResponse__Output>): grpc.ClientUnaryCall;
+  isReady(argument: _google_protobuf_Empty, callback: grpc.requestCallback<_sink_v1_ReadyResponse__Output>): grpc.ClientUnaryCall;
+  
+  /**
+   * SinkFn writes the request to a user defined sink.
+   */
+  SinkFn(metadata: grpc.Metadata, options?: grpc.CallOptions): grpc.ClientDuplexStream<_sink_v1_SinkRequest, _sink_v1_SinkResponse__Output>;
   SinkFn(options?: grpc.CallOptions): grpc.ClientDuplexStream<_sink_v1_SinkRequest, _sink_v1_SinkResponse__Output>;
-  sinkFn(
-    metadata: grpc.Metadata,
-    options?: grpc.CallOptions,
-  ): grpc.ClientDuplexStream<_sink_v1_SinkRequest, _sink_v1_SinkResponse__Output>;
+  /**
+   * SinkFn writes the request to a user defined sink.
+   */
+  sinkFn(metadata: grpc.Metadata, options?: grpc.CallOptions): grpc.ClientDuplexStream<_sink_v1_SinkRequest, _sink_v1_SinkResponse__Output>;
   sinkFn(options?: grpc.CallOptions): grpc.ClientDuplexStream<_sink_v1_SinkRequest, _sink_v1_SinkResponse__Output>;
+  
 }
 
 export interface SinkHandlers extends grpc.UntypedServiceImplementation {
+  /**
+   * IsReady is the heartbeat endpoint for gRPC.
+   */
   IsReady: grpc.handleUnaryCall<_google_protobuf_Empty__Output, _sink_v1_ReadyResponse>;
-
+  
+  /**
+   * SinkFn writes the request to a user defined sink.
+   */
   SinkFn: grpc.handleBidiStreamingCall<_sink_v1_SinkRequest__Output, _sink_v1_SinkResponse>;
+  
 }
 
 export interface SinkDefinition extends grpc.ServiceDefinition {
-  IsReady: MethodDefinition<
-    _google_protobuf_Empty,
-    _sink_v1_ReadyResponse,
-    _google_protobuf_Empty__Output,
-    _sink_v1_ReadyResponse__Output
-  >;
-  SinkFn: MethodDefinition<
-    _sink_v1_SinkRequest,
-    _sink_v1_SinkResponse,
-    _sink_v1_SinkRequest__Output,
-    _sink_v1_SinkResponse__Output
-  >;
+  IsReady: MethodDefinition<_google_protobuf_Empty, _sink_v1_ReadyResponse, _google_protobuf_Empty__Output, _sink_v1_ReadyResponse__Output>
+  SinkFn: MethodDefinition<_sink_v1_SinkRequest, _sink_v1_SinkResponse, _sink_v1_SinkRequest__Output, _sink_v1_SinkResponse__Output>
 }

--- a/src/sink/proto/sink/v1/SinkRequest.ts
+++ b/src/sink/proto/sink/v1/SinkRequest.ts
@@ -1,46 +1,63 @@
 // Original file: proto/sink.proto
 
-import type {
-  TransmissionStatus as _sink_v1_TransmissionStatus,
-  TransmissionStatus__Output as _sink_v1_TransmissionStatus__Output,
-} from '../../sink/v1/TransmissionStatus.ts';
-import type {
-  Handshake as _sink_v1_Handshake,
-  Handshake__Output as _sink_v1_Handshake__Output,
-} from '../../sink/v1/Handshake.ts';
-import type {
-  Timestamp as _google_protobuf_Timestamp,
-  Timestamp__Output as _google_protobuf_Timestamp__Output,
-} from '../../google/protobuf/Timestamp.ts';
+import type { TransmissionStatus as _sink_v1_TransmissionStatus, TransmissionStatus__Output as _sink_v1_TransmissionStatus__Output } from '../../sink/v1/TransmissionStatus.ts';
+import type { Handshake as _sink_v1_Handshake, Handshake__Output as _sink_v1_Handshake__Output } from '../../sink/v1/Handshake.ts';
+import type { Timestamp as _google_protobuf_Timestamp, Timestamp__Output as _google_protobuf_Timestamp__Output } from '../../google/protobuf/Timestamp.ts';
 
 export interface _sink_v1_SinkRequest_Request {
-  keys?: string[];
-  value?: Buffer | Uint8Array | string;
-  eventTime?: _google_protobuf_Timestamp | null;
-  watermark?: _google_protobuf_Timestamp | null;
-  id?: string;
-  headers?: { [key: string]: string };
+  'keys'?: (string)[];
+  'value'?: (Buffer | Uint8Array | string);
+  'eventTime'?: (_google_protobuf_Timestamp | null);
+  'watermark'?: (_google_protobuf_Timestamp | null);
+  'id'?: (string);
+  'headers'?: ({[key: string]: string});
 }
 
 export interface _sink_v1_SinkRequest_Request__Output {
-  keys: string[];
-  value: Buffer;
-  eventTime: _google_protobuf_Timestamp__Output | null;
-  watermark: _google_protobuf_Timestamp__Output | null;
-  id: string;
-  headers: { [key: string]: string };
+  'keys': (string)[];
+  'value': (Buffer);
+  'eventTime': (_google_protobuf_Timestamp__Output | null);
+  'watermark': (_google_protobuf_Timestamp__Output | null);
+  'id': (string);
+  'headers': ({[key: string]: string});
 }
 
+/**
+ * SinkRequest represents a request element.
+ */
 export interface SinkRequest {
-  request?: _sink_v1_SinkRequest_Request | null;
-  status?: _sink_v1_TransmissionStatus | null;
-  handshake?: _sink_v1_Handshake | null;
-  _handshake?: 'handshake';
+  /**
+   * Required field indicating the request.
+   */
+  'request'?: (_sink_v1_SinkRequest_Request | null);
+  /**
+   * Required field indicating the status of the request.
+   * If eot is set to true, it indicates the end of transmission.
+   */
+  'status'?: (_sink_v1_TransmissionStatus | null);
+  /**
+   * optional field indicating the handshake message.
+   */
+  'handshake'?: (_sink_v1_Handshake | null);
+  '_handshake'?: "handshake";
 }
 
+/**
+ * SinkRequest represents a request element.
+ */
 export interface SinkRequest__Output {
-  request: _sink_v1_SinkRequest_Request__Output | null;
-  status: _sink_v1_TransmissionStatus__Output | null;
-  handshake?: _sink_v1_Handshake__Output | null;
-  _handshake?: 'handshake';
+  /**
+   * Required field indicating the request.
+   */
+  'request': (_sink_v1_SinkRequest_Request__Output | null);
+  /**
+   * Required field indicating the status of the request.
+   * If eot is set to true, it indicates the end of transmission.
+   */
+  'status': (_sink_v1_TransmissionStatus__Output | null);
+  /**
+   * optional field indicating the handshake message.
+   */
+  'handshake'?: (_sink_v1_Handshake__Output | null);
+  '_handshake'?: "handshake";
 }

--- a/src/sink/proto/sink/v1/SinkResponse.ts
+++ b/src/sink/proto/sink/v1/SinkResponse.ts
@@ -1,43 +1,61 @@
 // Original file: proto/sink.proto
 
-import type {
-  Handshake as _sink_v1_Handshake,
-  Handshake__Output as _sink_v1_Handshake__Output,
-} from '../../sink/v1/Handshake.ts';
-import type {
-  TransmissionStatus as _sink_v1_TransmissionStatus,
-  TransmissionStatus__Output as _sink_v1_TransmissionStatus__Output,
-} from '../../sink/v1/TransmissionStatus.ts';
+import type { Handshake as _sink_v1_Handshake, Handshake__Output as _sink_v1_Handshake__Output } from '../../sink/v1/Handshake.ts';
+import type { TransmissionStatus as _sink_v1_TransmissionStatus, TransmissionStatus__Output as _sink_v1_TransmissionStatus__Output } from '../../sink/v1/TransmissionStatus.ts';
 import type { Status as _sink_v1_Status, Status__Output as _sink_v1_Status__Output } from '../../sink/v1/Status.ts';
 
 export interface _sink_v1_SinkResponse_Result {
-  id?: string;
-  status?: _sink_v1_Status;
-  errMsg?: string;
-  serveResponse?: Buffer | Uint8Array | string;
-  _serveResponse?: 'serveResponse';
+  /**
+   * id is the ID of the message, can be used to uniquely identify the message.
+   */
+  'id'?: (string);
+  /**
+   * status denotes the status of persisting to sink. It can be SUCCESS, FAILURE, or FALLBACK.
+   */
+  'status'?: (_sink_v1_Status);
+  /**
+   * err_msg is the error message, set it if success is set to false.
+   */
+  'errMsg'?: (string);
+  'serveResponse'?: (Buffer | Uint8Array | string);
+  '_serveResponse'?: "serveResponse";
 }
 
 export interface _sink_v1_SinkResponse_Result__Output {
-  id: string;
-  status: _sink_v1_Status__Output;
-  errMsg: string;
-  serveResponse?: Buffer;
-  _serveResponse?: 'serveResponse';
+  /**
+   * id is the ID of the message, can be used to uniquely identify the message.
+   */
+  'id': (string);
+  /**
+   * status denotes the status of persisting to sink. It can be SUCCESS, FAILURE, or FALLBACK.
+   */
+  'status': (_sink_v1_Status__Output);
+  /**
+   * err_msg is the error message, set it if success is set to false.
+   */
+  'errMsg': (string);
+  'serveResponse'?: (Buffer);
+  '_serveResponse'?: "serveResponse";
 }
 
+/**
+ * SinkResponse is the individual response of each message written to the sink.
+ */
 export interface SinkResponse {
-  results?: _sink_v1_SinkResponse_Result[];
-  handshake?: _sink_v1_Handshake | null;
-  status?: _sink_v1_TransmissionStatus | null;
-  _handshake?: 'handshake';
-  _status?: 'status';
+  'results'?: (_sink_v1_SinkResponse_Result)[];
+  'handshake'?: (_sink_v1_Handshake | null);
+  'status'?: (_sink_v1_TransmissionStatus | null);
+  '_handshake'?: "handshake";
+  '_status'?: "status";
 }
 
+/**
+ * SinkResponse is the individual response of each message written to the sink.
+ */
 export interface SinkResponse__Output {
-  results: _sink_v1_SinkResponse_Result__Output[];
-  handshake?: _sink_v1_Handshake__Output | null;
-  status?: _sink_v1_TransmissionStatus__Output | null;
-  _handshake?: 'handshake';
-  _status?: 'status';
+  'results': (_sink_v1_SinkResponse_Result__Output)[];
+  'handshake'?: (_sink_v1_Handshake__Output | null);
+  'status'?: (_sink_v1_TransmissionStatus__Output | null);
+  '_handshake'?: "handshake";
+  '_status'?: "status";
 }

--- a/src/sink/proto/sink/v1/Status.ts
+++ b/src/sink/proto/sink/v1/Status.ts
@@ -1,5 +1,8 @@
 // Original file: proto/sink.proto
 
+/**
+ * Status is the status of the response.
+ */
 export const Status = {
   SUCCESS: 'SUCCESS',
   FAILURE: 'FAILURE',
@@ -7,6 +10,20 @@ export const Status = {
   SERVE: 'SERVE',
 } as const;
 
-export type Status = 'SUCCESS' | 0 | 'FAILURE' | 1 | 'FALLBACK' | 2 | 'SERVE' | 3;
+/**
+ * Status is the status of the response.
+ */
+export type Status =
+  | 'SUCCESS'
+  | 0
+  | 'FAILURE'
+  | 1
+  | 'FALLBACK'
+  | 2
+  | 'SERVE'
+  | 3
 
-export type Status__Output = (typeof Status)[keyof typeof Status];
+/**
+ * Status is the status of the response.
+ */
+export type Status__Output = typeof Status[keyof typeof Status]

--- a/src/sink/proto/sink/v1/TransmissionStatus.ts
+++ b/src/sink/proto/sink/v1/TransmissionStatus.ts
@@ -1,9 +1,16 @@
 // Original file: proto/sink.proto
 
+
+/**
+ * TransmissionStatus is the status of the transmission.
+ */
 export interface TransmissionStatus {
-  eot?: boolean;
+  'eot'?: (boolean);
 }
 
+/**
+ * TransmissionStatus is the status of the transmission.
+ */
 export interface TransmissionStatus__Output {
-  eot: boolean;
+  'eot': (boolean);
 }

--- a/src/sink/service.test.ts
+++ b/src/sink/service.test.ts
@@ -5,39 +5,39 @@ import { ServerOpts } from '../common/server.js';
 import * as grpc from '@grpc/grpc-js';
 
 describe('SinkerService', () => {
-  let mockSinker: Sinker;
-  let serverOpts: ServerOpts;
+    let mockSinker: Sinker;
+    let serverOpts: ServerOpts;
 
-  beforeEach(() => {
-    mockSinker = {
-      sink: vi.fn().mockResolvedValue([]),
-    };
-    serverOpts = {
-      grpcMaxMessageSizeBytes: 1024 * 1024,
-    };
-  });
+    beforeEach(() => {
+        mockSinker = {
+            sink: vi.fn().mockResolvedValue([]),
+        };
+        serverOpts = {
+            grpcMaxMessageSizeBytes: 1024 * 1024,
+        };
+    });
 
-  it('should initialize with correct properties', () => {
-    const service = new SinkerService(mockSinker, serverOpts);
-    expect(service).toBeDefined();
-  });
+    it('should initialize with correct properties', () => {
+        const service = new SinkerService(mockSinker, serverOpts);
+        expect(service).toBeDefined();
+    });
 
-  it('should convert timestamp to Date correctly', () => {
-    const timestamp = { seconds: 1620000000, nanos: 500000000 };
-    const date = timestampToDate(timestamp);
-    expect(date).toEqual(new Date(1620000000 * 1000 + 500));
-  });
+    it('should convert timestamp to Date correctly', () => {
+        const timestamp = { seconds: 1620000000, nanos: 500000000 };
+        const date = timestampToDate(timestamp);
+        expect(date).toEqual(new Date(1620000000 * 1000 + 500));
+    });
 
-  it('should return null for invalid timestamp', () => {
-    const date = timestampToDate(null);
-    expect(date).toBeNull();
-  });
+    it('should return null for invalid timestamp', () => {
+        const date = timestampToDate(null);
+        expect(date).toBeNull();
+    });
 
-  it('should handle isReady correctly', () => {
-    const service = new SinkerService(mockSinker, serverOpts);
-    const call = {} as grpc.ServerUnaryCall<any, any>;
-    const callback = vi.fn();
-    service['isReady'](call, callback);
-    expect(callback).toHaveBeenCalledWith(null, { ready: true });
-  });
+    it('should handle isReady correctly', () => {
+        const service = new SinkerService(mockSinker, serverOpts);
+        const call = {} as grpc.ServerUnaryCall<any, any>;
+        const callback = vi.fn();
+        service['isReady'](call, callback);
+        expect(callback).toHaveBeenCalledWith(null, { ready: true });
+    });
 });

--- a/src/sink/service.ts
+++ b/src/sink/service.ts
@@ -20,220 +20,222 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const UD_CONTAINER_FALLBACK_SINK = 'fb-udsink';
 const Paths = {
-  SOCKET_PATH: '/var/run/numaflow/sink.sock',
-  SERVER_INFO_FILE_PATH: '/var/run/numaflow/sinker-server-info',
-  FALLBACK_ADDRESS: '/var/run/fallback.sock',
-  FALLBACK_SERVER_INFO_FILE_PATH: '/var/run/fallback-server-info',
+    SOCKET_PATH: '/var/run/numaflow/sink.sock',
+    SERVER_INFO_FILE_PATH: '/var/run/numaflow/sinker-server-info',
+    FALLBACK_ADDRESS: '/var/run/fallback.sock',
+    FALLBACK_SERVER_INFO_FILE_PATH: '/var/run/fallback-server-info',
 };
 
 export function timestampToDate(timestamp: Timestamp | null | undefined): Date | null {
-  if (!timestamp) {
-    return null;
-  }
-  const seconds = timestamp.seconds ?? 0;
-  const nanos = timestamp.nanos ?? 0;
-  return new Date(Number(seconds) * 1000 + Math.floor(Number(nanos) / 1e6));
+    if (!timestamp) {
+        return null;
+    }
+    const seconds = timestamp.seconds ?? 0;
+    const nanos = timestamp.nanos ?? 0;
+    return new Date(Number(seconds) * 1000 + Math.floor(Number(nanos) / 1e6));
 }
 
 export class SinkerService {
-  private sinker: Sinker;
-  private serverOpts: ServerOpts;
-  private address: string;
-  private serverInfoFilePath: string;
-  constructor(sinker: Sinker, opts: ServerOpts) {
-    this.sinker = sinker;
-    this.serverOpts = opts;
-    const isFallback = CONTAINER_TYPE === UD_CONTAINER_FALLBACK_SINK;
-    this.address = isFallback ? Paths.FALLBACK_ADDRESS : Paths.SOCKET_PATH;
-    this.serverInfoFilePath = isFallback ? Paths.FALLBACK_SERVER_INFO_FILE_PATH : Paths.SERVER_INFO_FILE_PATH;
-  }
-
-  start(this: SinkerService) {
-    const packageDef = protoLoader.loadSync(path.join(__dirname, '../../proto/sink.proto'), {});
-    const proto = grpc.loadPackageDefinition(packageDef) as unknown as ProtoGrpcType;
-    const serverInfo: ServerInfo = {
-      ...DEFAULT_SERVER_INFO,
-      minimum_numaflow_version: MinimumNumaflowVersions[ContainerTypes.Sinker],
-    };
-    prepareServer(serverInfo, this.serverInfoFilePath, this.address);
-    const server = new grpc.Server({
-      'grpc.max_send_message_length': this.serverOpts.grpcMaxMessageSizeBytes,
-      'grpc.max_receive_message_length': this.serverOpts.grpcMaxMessageSizeBytes,
-    });
-    const sinkServer: SinkHandlers = {
-      IsReady: this.isReady.bind(this),
-      SinkFn: this.sinkFn.bind(this),
-    };
-    server.addService(proto.sink.v1.Sink.service, sinkServer);
-    server.bindAsync(`unix://${this.address}`, grpc.ServerCredentials.createInsecure(), (err) => {
-      if (err) {
-        console.error('Failed to bind server:', err.message);
-        return;
-      }
-      console.log('Server bound successfully. Starting server...');
-    });
-  }
-
-  private isReady(call: grpc.ServerUnaryCall<Empty, ReadyResponse>, callback: grpc.sendUnaryData<ReadyResponse>) {
-    console.log(`Received isReady request`);
-    return callback(null, { ready: true });
-  }
-
-  private async sinkFn(call: grpc.ServerDuplexStream<SinkRequest, SinkResponse>): Promise<void> {
-    try {
-      const handshakeSuccessful = await this.performHandshake(call);
-      if (!handshakeSuccessful) {
-        throw new Error('Handshake failed');
-      }
-      let batch: Datum[] = [];
-      for await (const rawReq of call) {
-        let request = rawReq as SinkRequest;
-        if (request.status?.eot) {
-          await this.processDataAndSendEOT(call, batch);
-          batch = [];
-        } else {
-          if (request.request) {
-            const datum: Datum = this.createDatumFromRequest(request);
-            batch.push(datum);
-          }
-        }
-      }
-    } catch (err) {
-      console.error('Error in sinkFn:', err);
-      call.destroy();
-    } finally {
-      call.end();
-    }
-  }
-
-  private createDatumFromRequest(request: SinkRequest): Datum {
-    const buf = request.request?.value ?? '';
-    const payload = Buffer.isBuffer(buf) || buf instanceof Uint8Array ? buf : Buffer.from(buf);
-    return {
-      id: request.request?.id ?? '',
-      keys: request.request?.keys ?? [],
-      value: Buffer.isBuffer(payload) ? payload : Buffer.from(payload),
-      eventTime: timestampToDate(request.request?.eventTime),
-      watermark: timestampToDate(request.request?.watermark),
-      headers: request.request?.headers || {},
-    };
-  }
-
-  private async processDataAndSendEOT(
-    call: grpc.ServerDuplexStream<SinkRequest, SinkResponse>,
-    bufferedData: Datum[],
-  ): Promise<void> {
-    let resultsList: SinkResponseResult[] = [];
-    try {
-      const responses = await this.sinker.sink(bufferedData);
-      resultsList = responses.map((response) => {
-        if (response.fallback) {
-          return {
-            id: response.id,
-            status: Status.FALLBACK,
-          };
-        } else if (response.success) {
-          return {
-            id: response.id,
-            status: Status.SUCCESS,
-            serveResponse: response.serveResponse,
-          };
-        } else if (response.serve) {
-          return {
-            id: response.id,
-            status: Status.SERVE,
-            serveResponse: response.serveResponse,
-          };
-        } else {
-          return {
-            id: response.id,
-            status: Status.FAILURE,
-            errMsg: response.err,
-          };
-        }
-      });
-    } catch (err) {
-      console.error('processDataAndSendEOT: Error during sinker processing', err);
-      throw err;
+    private sinker: Sinker;
+    private serverOpts: ServerOpts;
+    private address: string;
+    private serverInfoFilePath: string;
+    constructor(sinker: Sinker, opts: ServerOpts) {
+        this.sinker = sinker;
+        this.serverOpts = opts;
+        const isFallback = CONTAINER_TYPE === UD_CONTAINER_FALLBACK_SINK;
+        this.address = isFallback ? Paths.FALLBACK_ADDRESS : Paths.SOCKET_PATH;
+        this.serverInfoFilePath = isFallback ? Paths.FALLBACK_SERVER_INFO_FILE_PATH : Paths.SERVER_INFO_FILE_PATH;
     }
 
-    if (resultsList.length > 0) {
-      const batchResponse: SinkResponse = { results: resultsList };
-      try {
-        await this.writeToCall(call, batchResponse);
-      } catch (writeErr) {
-        throw writeErr;
-      }
-    } else {
-      console.log('processDataAndEOT: No results to send for this batch.');
-    }
-
-    // Send Server EOT message
-    const eotResponse: SinkResponse = { status: { eot: true } };
-    try {
-      await this.writeToCall(call, eotResponse);
-    } catch (writeErr) {
-      throw writeErr;
-    }
-  }
-  private writeToCall(call: grpc.ServerDuplexStream<any, any>, message: any): Promise<void> {
-    return new Promise((resolve, reject) => {
-      if (call.writableEnded || call.destroyed) {
-        const reason = call.destroyed ? 'destroyed' : 'ended';
-        reject(new Error(`ERR_STREAM_${reason.toUpperCase()}: Cannot call write after a stream was ${reason}.`));
-        return;
-      }
-      call.write(message, (err?: Error | null) => {
-        if (err) {
-          reject(err);
-        } else {
-          resolve();
-        }
-      });
-    });
-  }
-
-  // Performs the handshake with the client.
-  private async performHandshake(call: grpc.ServerDuplexStream<SinkRequest, SinkResponse>): Promise<boolean> {
-    return new Promise((resolve, reject) => {
-      const cleanup = () => {
-        call.removeListener('data', onData);
-        call.removeListener('error', onError);
-      };
-
-      const onData = (rawRequest: SinkRequest) => {
-        cleanup();
-        const request = rawRequest as SinkRequest;
-
-        // Validate the handshake
-        if (!request.handshake || !request.handshake.sot) {
-          reject(new Error('Expected handshake message'));
-          return;
-        }
-
-        // Send the handshake response
-        const handshakeResponse: SinkResponse = {
-          handshake: {
-            sot: true,
-          },
+    start(this: SinkerService) {
+        const packageDef = protoLoader.loadSync(path.join(__dirname, '../../proto/sink.proto'), {});
+        const proto = grpc.loadPackageDefinition(packageDef) as unknown as ProtoGrpcType;
+        const serverInfo: ServerInfo = {
+            ...DEFAULT_SERVER_INFO,
+            minimum_numaflow_version: MinimumNumaflowVersions[ContainerTypes.Sinker],
         };
-        call.write(handshakeResponse, (err: any) => {
-          if (err) {
-            reject(err);
-          } else {
-            resolve(true);
-          }
+        prepareServer(serverInfo, this.serverInfoFilePath, this.address);
+        const server = new grpc.Server({
+            'grpc.max_send_message_length': this.serverOpts.grpcMaxMessageSizeBytes,
+            'grpc.max_receive_message_length': this.serverOpts.grpcMaxMessageSizeBytes,
         });
-      };
+        const sinkServer: SinkHandlers = {
+            IsReady: this.isReady.bind(this),
+            SinkFn: this.sinkFn.bind(this),
+        };
+        server.addService(proto.sink.v1.Sink.service, sinkServer);
+        server.bindAsync(`unix://${this.address}`, grpc.ServerCredentials.createInsecure(), (err) => {
+            if (err) {
+                console.error('Failed to bind server:', err.message);
+                return;
+            }
+            console.log('Server bound successfully. Starting server...');
+        });
+    }
 
-      const onError = (err: Error) => {
-        cleanup(); // Clean up listeners on error
-        console.error('Error during handshake:', err);
-        reject(err);
-      };
+    private isReady(call: grpc.ServerUnaryCall<Empty, ReadyResponse>, callback: grpc.sendUnaryData<ReadyResponse>) {
+        console.log(`Received isReady request`);
+        return callback(null, { ready: true });
+    }
 
-      call.once('data', onData);
-      call.once('error', onError);
-    });
-  }
+    private async sinkFn(call: grpc.ServerDuplexStream<SinkRequest, SinkResponse>): Promise<void> {
+        try {
+            const handshakeSuccessful = await this.performHandshake(call);
+            if (!handshakeSuccessful) {
+                throw new Error('Handshake failed');
+            }
+            let batch: Datum[] = [];
+            for await (const rawReq of call) {
+                let request = rawReq as SinkRequest;
+                if (request.status?.eot) {
+                    await this.processDataAndSendEOT(call, batch);
+                    batch = [];
+                } else {
+                    if (request.request) {
+                        const datum: Datum = this.createDatumFromRequest(request);
+                        batch.push(datum);
+                    }
+                }
+            }
+        } catch (err) {
+            console.error('Error in sinkFn:', err);
+            call.destroy();
+        } finally {
+            call.end();
+        }
+    }
+
+    private createDatumFromRequest(request: SinkRequest): Datum {
+        const buf = request.request?.value ?? '';
+        const payload = Buffer.isBuffer(buf) || buf instanceof Uint8Array ? buf : Buffer.from(buf);
+        return {
+            id: request.request?.id ?? '',
+            keys: request.request?.keys ?? [],
+            value: Buffer.isBuffer(payload) ? payload : Buffer.from(payload),
+            eventTime: timestampToDate(request.request?.eventTime),
+            watermark: timestampToDate(request.request?.watermark),
+            headers: request.request?.headers || {},
+        };
+    }
+
+    private async processDataAndSendEOT(
+        call: grpc.ServerDuplexStream<SinkRequest, SinkResponse>,
+        bufferedData: Datum[],
+    ): Promise<void> {
+        let resultsList: SinkResponseResult[] = [];
+        try {
+            const responses = await this.sinker.sink(bufferedData);
+            resultsList = responses.map((response) => {
+                if (response.fallback) {
+                    return {
+                        id: response.id,
+                        status: Status.FALLBACK,
+                    };
+                } else if (response.success) {
+                    return {
+                        id: response.id,
+                        status: Status.SUCCESS,
+                        serveResponse: response.serveResponse,
+                    };
+                } else if (response.serve) {
+                    return {
+                        id: response.id,
+                        status: Status.SERVE,
+                        serveResponse: response.serveResponse,
+                    };
+                } else {
+                    return {
+                        id: response.id,
+                        status: Status.FAILURE,
+                        errMsg: response.err,
+                    };
+                }
+            });
+        } catch (err) {
+            console.error('processDataAndSendEOT: Error during sinker processing', err);
+            throw err;
+        }
+
+        if (resultsList.length > 0) {
+            const batchResponse: SinkResponse = { results: resultsList };
+            try {
+                await this.writeToCall(call, batchResponse);
+            } catch (writeErr) {
+                throw writeErr;
+            }
+        } else {
+            console.log('processDataAndEOT: No results to send for this batch.');
+        }
+
+        // Send Server EOT message
+        const eotResponse: SinkResponse = { status: { eot: true } };
+        try {
+            await this.writeToCall(call, eotResponse);
+        } catch (writeErr) {
+            throw writeErr;
+        }
+    }
+    private writeToCall(call: grpc.ServerDuplexStream<any, any>, message: any): Promise<void> {
+        return new Promise((resolve, reject) => {
+            if (call.writableEnded || call.destroyed) {
+                const reason = call.destroyed ? 'destroyed' : 'ended';
+                reject(
+                    new Error(`ERR_STREAM_${reason.toUpperCase()}: Cannot call write after a stream was ${reason}.`),
+                );
+                return;
+            }
+            call.write(message, (err?: Error | null) => {
+                if (err) {
+                    reject(err);
+                } else {
+                    resolve();
+                }
+            });
+        });
+    }
+
+    // Performs the handshake with the client.
+    private async performHandshake(call: grpc.ServerDuplexStream<SinkRequest, SinkResponse>): Promise<boolean> {
+        return new Promise((resolve, reject) => {
+            const cleanup = () => {
+                call.removeListener('data', onData);
+                call.removeListener('error', onError);
+            };
+
+            const onData = (rawRequest: SinkRequest) => {
+                cleanup();
+                const request = rawRequest as SinkRequest;
+
+                // Validate the handshake
+                if (!request.handshake || !request.handshake.sot) {
+                    reject(new Error('Expected handshake message'));
+                    return;
+                }
+
+                // Send the handshake response
+                const handshakeResponse: SinkResponse = {
+                    handshake: {
+                        sot: true,
+                    },
+                };
+                call.write(handshakeResponse, (err: any) => {
+                    if (err) {
+                        reject(err);
+                    } else {
+                        resolve(true);
+                    }
+                });
+            };
+
+            const onError = (err: Error) => {
+                cleanup(); // Clean up listeners on error
+                console.error('Error during handshake:', err);
+                reject(err);
+            };
+
+            call.once('data', onData);
+            call.once('error', onError);
+        });
+    }
 }

--- a/src/sink/types.ts
+++ b/src/sink/types.ts
@@ -1,21 +1,21 @@
 export interface Response {
-  id: string;
-  success?: boolean;
-  fallback?: boolean;
-  serve?: boolean;
-  serveResponse?: Uint8Array;
-  err?: string;
+    id: string;
+    success?: boolean;
+    fallback?: boolean;
+    serve?: boolean;
+    serveResponse?: Uint8Array;
+    err?: string;
 }
 
 export interface Datum {
-  id: string;
-  keys: string[];
-  value: Buffer;
-  eventTime: Date | null;
-  watermark: Date | null;
-  headers: Record<string, string>;
+    id: string;
+    keys: string[];
+    value: Buffer;
+    eventTime: Date | null;
+    watermark: Date | null;
+    headers: Record<string, string>;
 }
 
 export interface Sinker {
-  sink(data: Datum[]): Promise<Response[]>;
+    sink(data: Datum[]): Promise<Response[]>;
 }

--- a/src/source/index.ts
+++ b/src/source/index.ts
@@ -14,20 +14,20 @@ import type { PendingResponse } from './proto/source/v1/PendingResponse.ts';
 import type { PartitionsResponse } from './proto/source/v1/PartitionsResponse.ts';
 import { Sourcer, ReadRequest as NumaSourceReadRequest, Offset as NumaSourceOffset } from './types.js';
 import {
-  DEFAULT_MAX_MESSAGE_SIZE,
-  DEFAULT_SERVER_INFO,
-  parseServerOptions,
-  prepareServer,
-  ServerInfo,
-  ServerOpts,
+    DEFAULT_MAX_MESSAGE_SIZE,
+    DEFAULT_SERVER_INFO,
+    parseServerOptions,
+    prepareServer,
+    ServerInfo,
+    ServerOpts,
 } from '../common/server.js';
 import { ContainerTypes, MinimumNumaflowVersions } from '../common/constants.js';
 
 export { createOffsetWithDefaultPartitionId } from './types.js';
 
 const Paths = {
-  SOCKET_PATH: '/var/run/numaflow/source.sock',
-  SERVER_INFO_FILE_PATH: '/var/run/numaflow/sourcer-server-info',
+    SOCKET_PATH: '/var/run/numaflow/source.sock',
+    SERVER_INFO_FILE_PATH: '/var/run/numaflow/sourcer-server-info',
 };
 
 // Resolve the current directory
@@ -35,156 +35,156 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 class SourcerService {
-  constructor(
-    private sourcer: Sourcer,
-    private opts: ServerOpts,
-  ) {}
+    constructor(
+        private sourcer: Sourcer,
+        private opts: ServerOpts,
+    ) {}
 
-  start(this: SourcerService) {
-    const packageDef = protoLoader.loadSync(path.join(__dirname, '../../proto/source.proto'), {});
-    const proto = grpc.loadPackageDefinition(packageDef) as unknown as ProtoGrpcType;
+    start(this: SourcerService) {
+        const packageDef = protoLoader.loadSync(path.join(__dirname, '../../proto/source.proto'), {});
+        const proto = grpc.loadPackageDefinition(packageDef) as unknown as ProtoGrpcType;
 
-    const sourceServer: SourceHandlers = {
-      IsReady: this.isReady.bind(this),
-      ReadFn: this.readFn.bind(this),
-      AckFn: this.ackFn.bind(this),
-      PendingFn: this.pendingFn.bind(this),
-      PartitionsFn: this.partitionFn.bind(this),
-    };
+        const sourceServer: SourceHandlers = {
+            IsReady: this.isReady.bind(this),
+            ReadFn: this.readFn.bind(this),
+            AckFn: this.ackFn.bind(this),
+            PendingFn: this.pendingFn.bind(this),
+            PartitionsFn: this.partitionFn.bind(this),
+        };
 
-    const serverInfo: ServerInfo = {
-      ...DEFAULT_SERVER_INFO,
-      minimum_numaflow_version: MinimumNumaflowVersions[ContainerTypes.Sourcer],
-    };
-    prepareServer(serverInfo, Paths.SERVER_INFO_FILE_PATH, Paths.SOCKET_PATH);
-    const server = new grpc.Server({
-      'grpc.max_send_message_length': this.opts.grpcMaxMessageSizeBytes,
-      'grpc.max_receive_message_length': this.opts.grpcMaxMessageSizeBytes,
-    });
-    server.addService(proto.source.v1.Source.service, sourceServer);
-    server.bindAsync(`unix://${Paths.SOCKET_PATH}`, grpc.ServerCredentials.createInsecure(), (err) => {
-      if (err) {
-        console.error('Failed to bind server:', err.message);
-        return;
-      }
-      console.log('Server bound successfully. Starting server...');
-    });
-  }
-
-  isReady(call: grpc.ServerUnaryCall<Empty, ReadyResponse>, callback: grpc.sendUnaryData<ReadyResponse>) {
-    console.log(`Received isReady request`);
-    return callback(null, { ready: true });
-  }
-
-  readFn(call: grpc.ServerDuplexStream<ReadRequest, ReadResponse>) {
-    console.log('Read Fn called');
-    let handshakeDone = false;
-    call.on('data', async (request: ReadRequest) => {
-      if (!handshakeDone) {
-        if (!request.handshake?.sot) {
-          console.error('Expected handshake message');
-        }
-        handshakeDone = true;
-        call.write({ handshake: { sot: true } });
-        console.log('Handshake completed');
-        return;
-      }
-      if (request.request) {
-        const readRequest = {
-          timeout_ms: request.request.timeoutInMs ?? 1000,
-          count: request.request.numRecords ?? 500,
-        } as NumaSourceReadRequest;
-        const responses = await this.sourcer.read(readRequest);
-        for (const msg of responses) {
-          const headers: Record<string, string> = {};
-          msg.headers?.forEach((value, key) => {
-            headers[key as string] = value;
-          });
-
-          call.write({
-            result: {
-              payload: msg.value,
-              offset: {
-                offset: msg.offset.value,
-                partitionId: msg.offset.partitionId,
-              },
-              eventTime: {
-                seconds: Math.floor(msg.eventTime.getTime() / 1000),
-              },
-              keys: msg.keys,
-              headers,
-            },
-            status: { eot: false, code: 0 },
-          });
-        }
-        call.write({
-          status: { eot: true, code: 0 },
+        const serverInfo: ServerInfo = {
+            ...DEFAULT_SERVER_INFO,
+            minimum_numaflow_version: MinimumNumaflowVersions[ContainerTypes.Sourcer],
+        };
+        prepareServer(serverInfo, Paths.SERVER_INFO_FILE_PATH, Paths.SOCKET_PATH);
+        const server = new grpc.Server({
+            'grpc.max_send_message_length': this.opts.grpcMaxMessageSizeBytes,
+            'grpc.max_receive_message_length': this.opts.grpcMaxMessageSizeBytes,
         });
-        console.log(`Sent EOT`);
-        return;
-      }
-      console.log(`Invalid Source request: ${JSON.stringify(request, null, 2)}`);
-      throw { message: `invalid request: ${request}` };
-    });
-
-    call.on('end', () => {
-      console.log('Stream ended');
-      call.end(); // End the stream
-    });
-  }
-
-  ackFn(call: grpc.ServerDuplexStream<AckRequest, AckResponse>) {
-    console.log('AckFn called');
-    let handshakeDone = false;
-    call.on('data', async (request: AckRequest) => {
-      if (!handshakeDone) {
-        if (!request.handshake?.sot) {
-          console.error('Expected handshake message');
-        }
-        handshakeDone = true;
-        call.write({ handshake: { sot: true } });
-        console.log('AckFn Handshake completed');
-        return;
-      }
-      if (request.request) {
-        const offsets: NumaSourceOffset[] = (request.request.offsets ?? []).map((offset) => ({
-          value: Buffer.isBuffer(offset.offset) ? offset.offset : Buffer.from(offset.offset as string),
-          partitionId: offset.partitionId ?? 0,
-        }));
-        console.log(`Received ack request for ${offsets.length} messages`);
-        await this.sourcer.ack(offsets);
-        call.write({
-          result: {
-            success: {},
-          },
+        server.addService(proto.source.v1.Source.service, sourceServer);
+        server.bindAsync(`unix://${Paths.SOCKET_PATH}`, grpc.ServerCredentials.createInsecure(), (err) => {
+            if (err) {
+                console.error('Failed to bind server:', err.message);
+                return;
+            }
+            console.log('Server bound successfully. Starting server...');
         });
-        return;
-      }
-      console.log(`Invalid Ack request: ${JSON.stringify(request, null, 2)}`);
-      throw { message: `invalid request: ${request}` };
-    });
+    }
 
-    call.on('end', () => {
-      console.log('Stream ended');
-      call.end(); // End the stream
-    });
-  }
+    isReady(call: grpc.ServerUnaryCall<Empty, ReadyResponse>, callback: grpc.sendUnaryData<ReadyResponse>) {
+        console.log(`Received isReady request`);
+        return callback(null, { ready: true });
+    }
 
-  async pendingFn(call: grpc.ServerUnaryCall<{}, PendingResponse>, callback: grpc.sendUnaryData<PendingResponse>) {
-    const pending = await this.sourcer.pending();
-    return callback(null, { result: { count: pending } });
-  }
+    readFn(call: grpc.ServerDuplexStream<ReadRequest, ReadResponse>) {
+        console.log('Read Fn called');
+        let handshakeDone = false;
+        call.on('data', async (request: ReadRequest) => {
+            if (!handshakeDone) {
+                if (!request.handshake?.sot) {
+                    console.error('Expected handshake message');
+                }
+                handshakeDone = true;
+                call.write({ handshake: { sot: true } });
+                console.log('Handshake completed');
+                return;
+            }
+            if (request.request) {
+                const readRequest = {
+                    timeout_ms: request.request.timeoutInMs ?? 1000,
+                    count: request.request.numRecords ?? 500,
+                } as NumaSourceReadRequest;
+                const responses = await this.sourcer.read(readRequest);
+                for (const msg of responses) {
+                    const headers: Record<string, string> = {};
+                    msg.headers?.forEach((value, key) => {
+                        headers[key as string] = value;
+                    });
 
-  async partitionFn(
-    call: grpc.ServerUnaryCall<{}, PartitionsResponse>,
-    callback: grpc.sendUnaryData<PartitionsResponse>,
-  ) {
-    const partitions = await this.sourcer.partitions();
-    return callback(null, { result: { partitions: partitions } });
-  }
+                    call.write({
+                        result: {
+                            payload: msg.value,
+                            offset: {
+                                offset: msg.offset.value,
+                                partitionId: msg.offset.partitionId,
+                            },
+                            eventTime: {
+                                seconds: Math.floor(msg.eventTime.getTime() / 1000),
+                            },
+                            keys: msg.keys,
+                            headers,
+                        },
+                        status: { eot: false, code: 0 },
+                    });
+                }
+                call.write({
+                    status: { eot: true, code: 0 },
+                });
+                console.log(`Sent EOT`);
+                return;
+            }
+            console.log(`Invalid Source request: ${JSON.stringify(request, null, 2)}`);
+            throw { message: `invalid request: ${request}` };
+        });
+
+        call.on('end', () => {
+            console.log('Stream ended');
+            call.end(); // End the stream
+        });
+    }
+
+    ackFn(call: grpc.ServerDuplexStream<AckRequest, AckResponse>) {
+        console.log('AckFn called');
+        let handshakeDone = false;
+        call.on('data', async (request: AckRequest) => {
+            if (!handshakeDone) {
+                if (!request.handshake?.sot) {
+                    console.error('Expected handshake message');
+                }
+                handshakeDone = true;
+                call.write({ handshake: { sot: true } });
+                console.log('AckFn Handshake completed');
+                return;
+            }
+            if (request.request) {
+                const offsets: NumaSourceOffset[] = (request.request.offsets ?? []).map((offset) => ({
+                    value: Buffer.isBuffer(offset.offset) ? offset.offset : Buffer.from(offset.offset as string),
+                    partitionId: offset.partitionId ?? 0,
+                }));
+                console.log(`Received ack request for ${offsets.length} messages`);
+                await this.sourcer.ack(offsets);
+                call.write({
+                    result: {
+                        success: {},
+                    },
+                });
+                return;
+            }
+            console.log(`Invalid Ack request: ${JSON.stringify(request, null, 2)}`);
+            throw { message: `invalid request: ${request}` };
+        });
+
+        call.on('end', () => {
+            console.log('Stream ended');
+            call.end(); // End the stream
+        });
+    }
+
+    async pendingFn(call: grpc.ServerUnaryCall<{}, PendingResponse>, callback: grpc.sendUnaryData<PendingResponse>) {
+        const pending = await this.sourcer.pending();
+        return callback(null, { result: { count: pending } });
+    }
+
+    async partitionFn(
+        call: grpc.ServerUnaryCall<{}, PartitionsResponse>,
+        callback: grpc.sendUnaryData<PartitionsResponse>,
+    ) {
+        const partitions = await this.sourcer.partitions();
+        return callback(null, { result: { partitions: partitions } });
+    }
 }
 
 export function createServer(source: Sourcer, options?: ServerOpts): SourcerService {
-  const opts = parseServerOptions(options);
-  return new SourcerService(source, opts);
+    const opts = parseServerOptions(options);
+    return new SourcerService(source, opts);
 }

--- a/src/source/proto/google/protobuf/Empty.ts
+++ b/src/source/proto/google/protobuf/Empty.ts
@@ -1,5 +1,8 @@
 // Original file: null
 
-export interface Empty {}
 
-export interface Empty__Output {}
+export interface Empty {
+}
+
+export interface Empty__Output {
+}

--- a/src/source/proto/google/protobuf/Timestamp.ts
+++ b/src/source/proto/google/protobuf/Timestamp.ts
@@ -3,11 +3,11 @@
 import type { Long } from '@grpc/proto-loader';
 
 export interface Timestamp {
-  seconds?: number | string | Long;
-  nanos?: number;
+  'seconds'?: (number | string | Long);
+  'nanos'?: (number);
 }
 
 export interface Timestamp__Output {
-  seconds: string;
-  nanos: number;
+  'seconds': (string);
+  'nanos': (number);
 }

--- a/src/source/proto/source.ts
+++ b/src/source/proto/source.ts
@@ -1,36 +1,32 @@
 import type * as grpc from '@grpc/grpc-js';
 import type { MessageTypeDefinition } from '@grpc/proto-loader';
 
-import type {
-  SourceClient as _source_v1_SourceClient,
-  SourceDefinition as _source_v1_SourceDefinition,
-} from './source/v1/Source.ts';
+import type { SourceClient as _source_v1_SourceClient, SourceDefinition as _source_v1_SourceDefinition } from './source/v1/Source.ts';
 
 type SubtypeConstructor<Constructor extends new (...args: any) => any, Subtype> = {
-  new (...args: ConstructorParameters<Constructor>): Subtype;
+  new(...args: ConstructorParameters<Constructor>): Subtype;
 };
 
 export interface ProtoGrpcType {
   google: {
     protobuf: {
-      Empty: MessageTypeDefinition;
-      Timestamp: MessageTypeDefinition;
-    };
-  };
+      Empty: MessageTypeDefinition
+      Timestamp: MessageTypeDefinition
+    }
+  }
   source: {
     v1: {
-      AckRequest: MessageTypeDefinition;
-      AckResponse: MessageTypeDefinition;
-      Handshake: MessageTypeDefinition;
-      Offset: MessageTypeDefinition;
-      PartitionsResponse: MessageTypeDefinition;
-      PendingResponse: MessageTypeDefinition;
-      ReadRequest: MessageTypeDefinition;
-      ReadResponse: MessageTypeDefinition;
-      ReadyResponse: MessageTypeDefinition;
-      Source: SubtypeConstructor<typeof grpc.Client, _source_v1_SourceClient> & {
-        service: _source_v1_SourceDefinition;
-      };
-    };
-  };
+      AckRequest: MessageTypeDefinition
+      AckResponse: MessageTypeDefinition
+      Handshake: MessageTypeDefinition
+      Offset: MessageTypeDefinition
+      PartitionsResponse: MessageTypeDefinition
+      PendingResponse: MessageTypeDefinition
+      ReadRequest: MessageTypeDefinition
+      ReadResponse: MessageTypeDefinition
+      ReadyResponse: MessageTypeDefinition
+      Source: SubtypeConstructor<typeof grpc.Client, _source_v1_SourceClient> & { service: _source_v1_SourceDefinition }
+    }
+  }
 }
+

--- a/src/source/proto/source/v1/AckRequest.ts
+++ b/src/source/proto/source/v1/AckRequest.ts
@@ -1,30 +1,44 @@
 // Original file: proto/source.proto
 
-import type {
-  Handshake as _source_v1_Handshake,
-  Handshake__Output as _source_v1_Handshake__Output,
-} from '../../source/v1/Handshake.ts';
-import type {
-  Offset as _source_v1_Offset,
-  Offset__Output as _source_v1_Offset__Output,
-} from '../../source/v1/Offset.ts';
+import type { Handshake as _source_v1_Handshake, Handshake__Output as _source_v1_Handshake__Output } from '../../source/v1/Handshake.ts';
+import type { Offset as _source_v1_Offset, Offset__Output as _source_v1_Offset__Output } from '../../source/v1/Offset.ts';
 
 export interface _source_v1_AckRequest_Request {
-  offsets?: _source_v1_Offset[];
+  /**
+   * Required field holding the offset to be acked
+   */
+  'offsets'?: (_source_v1_Offset)[];
 }
 
 export interface _source_v1_AckRequest_Request__Output {
-  offsets: _source_v1_Offset__Output[];
+  /**
+   * Required field holding the offset to be acked
+   */
+  'offsets': (_source_v1_Offset__Output)[];
 }
 
+/**
+ * AckRequest is the request for acknowledging datum.
+ * It takes a list of offsets to be acknowledged.
+ */
 export interface AckRequest {
-  request?: _source_v1_AckRequest_Request | null;
-  handshake?: _source_v1_Handshake | null;
-  _handshake?: 'handshake';
+  /**
+   * Required field holding the request. The list will be ordered and will have the same order as the original Read response.
+   */
+  'request'?: (_source_v1_AckRequest_Request | null);
+  'handshake'?: (_source_v1_Handshake | null);
+  '_handshake'?: "handshake";
 }
 
+/**
+ * AckRequest is the request for acknowledging datum.
+ * It takes a list of offsets to be acknowledged.
+ */
 export interface AckRequest__Output {
-  request: _source_v1_AckRequest_Request__Output | null;
-  handshake?: _source_v1_Handshake__Output | null;
-  _handshake?: 'handshake';
+  /**
+   * Required field holding the request. The list will be ordered and will have the same order as the original Read response.
+   */
+  'request': (_source_v1_AckRequest_Request__Output | null);
+  'handshake'?: (_source_v1_Handshake__Output | null);
+  '_handshake'?: "handshake";
 }

--- a/src/source/proto/source/v1/AckResponse.ts
+++ b/src/source/proto/source/v1/AckResponse.ts
@@ -1,30 +1,62 @@
 // Original file: proto/source.proto
 
-import type {
-  Handshake as _source_v1_Handshake,
-  Handshake__Output as _source_v1_Handshake__Output,
-} from '../../source/v1/Handshake.ts';
-import type {
-  Empty as _google_protobuf_Empty,
-  Empty__Output as _google_protobuf_Empty__Output,
-} from '../../google/protobuf/Empty.ts';
+import type { Handshake as _source_v1_Handshake, Handshake__Output as _source_v1_Handshake__Output } from '../../source/v1/Handshake.ts';
+import type { Empty as _google_protobuf_Empty, Empty__Output as _google_protobuf_Empty__Output } from '../../google/protobuf/Empty.ts';
 
 export interface _source_v1_AckResponse_Result {
-  success?: _google_protobuf_Empty | null;
+  /**
+   * Required field indicating the ack request is successful.
+   */
+  'success'?: (_google_protobuf_Empty | null);
 }
 
 export interface _source_v1_AckResponse_Result__Output {
-  success: _google_protobuf_Empty__Output | null;
+  /**
+   * Required field indicating the ack request is successful.
+   */
+  'success': (_google_protobuf_Empty__Output | null);
 }
 
+/**
+ * AckResponse is the response for acknowledging datum. It contains one empty field confirming
+ * the batch of offsets that have been successfully acknowledged. The contract between client and server
+ * is that the server will only return the AckResponse if the ack request is successful.
+ * If the server hangs during the ack request, the client can decide to timeout and error out the data forwarder.
+ * The reason why we define such contract is that we always expect the server to be able to process the ack request.
+ * Client is expected to send the AckRequest to the server with offsets that are strictly
+ * corresponding to the previously read batch. If the client sends the AckRequest with offsets that are not,
+ * it is considered as a client error and the server will not return the AckResponse.
+ */
 export interface AckResponse {
-  result?: _source_v1_AckResponse_Result | null;
-  handshake?: _source_v1_Handshake | null;
-  _handshake?: 'handshake';
+  /**
+   * Required field holding the result.
+   */
+  'result'?: (_source_v1_AckResponse_Result | null);
+  /**
+   * Handshake message between client and server to indicate the start of transmission.
+   */
+  'handshake'?: (_source_v1_Handshake | null);
+  '_handshake'?: "handshake";
 }
 
+/**
+ * AckResponse is the response for acknowledging datum. It contains one empty field confirming
+ * the batch of offsets that have been successfully acknowledged. The contract between client and server
+ * is that the server will only return the AckResponse if the ack request is successful.
+ * If the server hangs during the ack request, the client can decide to timeout and error out the data forwarder.
+ * The reason why we define such contract is that we always expect the server to be able to process the ack request.
+ * Client is expected to send the AckRequest to the server with offsets that are strictly
+ * corresponding to the previously read batch. If the client sends the AckRequest with offsets that are not,
+ * it is considered as a client error and the server will not return the AckResponse.
+ */
 export interface AckResponse__Output {
-  result: _source_v1_AckResponse_Result__Output | null;
-  handshake?: _source_v1_Handshake__Output | null;
-  _handshake?: 'handshake';
+  /**
+   * Required field holding the result.
+   */
+  'result': (_source_v1_AckResponse_Result__Output | null);
+  /**
+   * Handshake message between client and server to indicate the start of transmission.
+   */
+  'handshake'?: (_source_v1_Handshake__Output | null);
+  '_handshake'?: "handshake";
 }

--- a/src/source/proto/source/v1/Handshake.ts
+++ b/src/source/proto/source/v1/Handshake.ts
@@ -1,9 +1,22 @@
 // Original file: proto/source.proto
 
+
+/**
+ * Handshake message between client and server to indicate the start of transmission.
+ */
 export interface Handshake {
-  sot?: boolean;
+  /**
+   * Required field indicating the start of transmission.
+   */
+  'sot'?: (boolean);
 }
 
+/**
+ * Handshake message between client and server to indicate the start of transmission.
+ */
 export interface Handshake__Output {
-  sot: boolean;
+  /**
+   * Required field indicating the start of transmission.
+   */
+  'sot': (boolean);
 }

--- a/src/source/proto/source/v1/Offset.ts
+++ b/src/source/proto/source/v1/Offset.ts
@@ -1,11 +1,40 @@
 // Original file: proto/source.proto
 
+
+/**
+ * Offset is the offset of the datum.
+ */
 export interface Offset {
-  offset?: Buffer | Uint8Array | string;
-  partitionId?: number;
+  /**
+   * offset is the offset of the datum. This field is required.
+   * We define Offset as a byte array because different input data sources can have different representations for Offset.
+   * The only way to generalize it is to define it as a byte array,
+   * Such that we can let the UDSource to de-serialize the offset using its own interpretation logics.
+   */
+  'offset'?: (Buffer | Uint8Array | string);
+  /**
+   * Optional partition_id indicates which partition of the source the datum belongs to.
+   * It is useful for sources that have multiple partitions. e.g. Kafka.
+   * If the partition_id is not specified, it is assumed that the source has a single partition.
+   */
+  'partitionId'?: (number);
 }
 
+/**
+ * Offset is the offset of the datum.
+ */
 export interface Offset__Output {
-  offset: Buffer;
-  partitionId: number;
+  /**
+   * offset is the offset of the datum. This field is required.
+   * We define Offset as a byte array because different input data sources can have different representations for Offset.
+   * The only way to generalize it is to define it as a byte array,
+   * Such that we can let the UDSource to de-serialize the offset using its own interpretation logics.
+   */
+  'offset': (Buffer);
+  /**
+   * Optional partition_id indicates which partition of the source the datum belongs to.
+   * It is useful for sources that have multiple partitions. e.g. Kafka.
+   * If the partition_id is not specified, it is assumed that the source has a single partition.
+   */
+  'partitionId': (number);
 }

--- a/src/source/proto/source/v1/PartitionsResponse.ts
+++ b/src/source/proto/source/v1/PartitionsResponse.ts
@@ -1,17 +1,36 @@
 // Original file: proto/source.proto
 
+
 export interface _source_v1_PartitionsResponse_Result {
-  partitions?: number[];
+  /**
+   * Required field holding the list of partitions.
+   */
+  'partitions'?: (number)[];
 }
 
 export interface _source_v1_PartitionsResponse_Result__Output {
-  partitions: number[];
+  /**
+   * Required field holding the list of partitions.
+   */
+  'partitions': (number)[];
 }
 
+/**
+ * PartitionsResponse is the response for the partitions request.
+ */
 export interface PartitionsResponse {
-  result?: _source_v1_PartitionsResponse_Result | null;
+  /**
+   * Required field holding the result.
+   */
+  'result'?: (_source_v1_PartitionsResponse_Result | null);
 }
 
+/**
+ * PartitionsResponse is the response for the partitions request.
+ */
 export interface PartitionsResponse__Output {
-  result: _source_v1_PartitionsResponse_Result__Output | null;
+  /**
+   * Required field holding the result.
+   */
+  'result': (_source_v1_PartitionsResponse_Result__Output | null);
 }

--- a/src/source/proto/source/v1/PendingResponse.ts
+++ b/src/source/proto/source/v1/PendingResponse.ts
@@ -3,17 +3,37 @@
 import type { Long } from '@grpc/proto-loader';
 
 export interface _source_v1_PendingResponse_Result {
-  count?: number | string | Long;
+  /**
+   * Required field holding the number of pending records at the user defined source.
+   * A negative count indicates that the pending information is not available.
+   */
+  'count'?: (number | string | Long);
 }
 
 export interface _source_v1_PendingResponse_Result__Output {
-  count: string;
+  /**
+   * Required field holding the number of pending records at the user defined source.
+   * A negative count indicates that the pending information is not available.
+   */
+  'count': (string);
 }
 
+/**
+ * PendingResponse is the response for the pending request.
+ */
 export interface PendingResponse {
-  result?: _source_v1_PendingResponse_Result | null;
+  /**
+   * Required field holding the result.
+   */
+  'result'?: (_source_v1_PendingResponse_Result | null);
 }
 
+/**
+ * PendingResponse is the response for the pending request.
+ */
 export interface PendingResponse__Output {
-  result: _source_v1_PendingResponse_Result__Output | null;
+  /**
+   * Required field holding the result.
+   */
+  'result': (_source_v1_PendingResponse_Result__Output | null);
 }

--- a/src/source/proto/source/v1/ReadRequest.ts
+++ b/src/source/proto/source/v1/ReadRequest.ts
@@ -1,29 +1,54 @@
 // Original file: proto/source.proto
 
-import type {
-  Handshake as _source_v1_Handshake,
-  Handshake__Output as _source_v1_Handshake__Output,
-} from '../../source/v1/Handshake.ts';
+import type { Handshake as _source_v1_Handshake, Handshake__Output as _source_v1_Handshake__Output } from '../../source/v1/Handshake.ts';
 import type { Long } from '@grpc/proto-loader';
 
 export interface _source_v1_ReadRequest_Request {
-  numRecords?: number | string | Long;
-  timeoutInMs?: number;
+  /**
+   * Required field indicating the number of records to read.
+   */
+  'numRecords'?: (number | string | Long);
+  /**
+   * Required field indicating the request timeout in milliseconds.
+   * uint32 can represent 2^32 milliseconds, which is about 49 days.
+   * We don't use uint64 because time.Duration takes int64 as nano seconds. Using uint64 for milli will cause overflow.
+   */
+  'timeoutInMs'?: (number);
 }
 
 export interface _source_v1_ReadRequest_Request__Output {
-  numRecords: string;
-  timeoutInMs: number;
+  /**
+   * Required field indicating the number of records to read.
+   */
+  'numRecords': (string);
+  /**
+   * Required field indicating the request timeout in milliseconds.
+   * uint32 can represent 2^32 milliseconds, which is about 49 days.
+   * We don't use uint64 because time.Duration takes int64 as nano seconds. Using uint64 for milli will cause overflow.
+   */
+  'timeoutInMs': (number);
 }
 
+/**
+ * ReadRequest is the request for reading datum stream from user defined source.
+ */
 export interface ReadRequest {
-  request?: _source_v1_ReadRequest_Request | null;
-  handshake?: _source_v1_Handshake | null;
-  _handshake?: 'handshake';
+  /**
+   * Required field indicating the request.
+   */
+  'request'?: (_source_v1_ReadRequest_Request | null);
+  'handshake'?: (_source_v1_Handshake | null);
+  '_handshake'?: "handshake";
 }
 
+/**
+ * ReadRequest is the request for reading datum stream from user defined source.
+ */
 export interface ReadRequest__Output {
-  request: _source_v1_ReadRequest_Request__Output | null;
-  handshake?: _source_v1_Handshake__Output | null;
-  _handshake?: 'handshake';
+  /**
+   * Required field indicating the request.
+   */
+  'request': (_source_v1_ReadRequest_Request__Output | null);
+  'handshake'?: (_source_v1_Handshake__Output | null);
+  '_handshake'?: "handshake";
 }

--- a/src/source/proto/source/v1/ReadResponse.ts
+++ b/src/source/proto/source/v1/ReadResponse.ts
@@ -1,86 +1,171 @@
 // Original file: proto/source.proto
 
-import type {
-  Handshake as _source_v1_Handshake,
-  Handshake__Output as _source_v1_Handshake__Output,
-} from '../../source/v1/Handshake.ts';
-import type {
-  Offset as _source_v1_Offset,
-  Offset__Output as _source_v1_Offset__Output,
-} from '../../source/v1/Offset.ts';
-import type {
-  Timestamp as _google_protobuf_Timestamp,
-  Timestamp__Output as _google_protobuf_Timestamp__Output,
-} from '../../google/protobuf/Timestamp.ts';
+import type { Handshake as _source_v1_Handshake, Handshake__Output as _source_v1_Handshake__Output } from '../../source/v1/Handshake.ts';
+import type { Offset as _source_v1_Offset, Offset__Output as _source_v1_Offset__Output } from '../../source/v1/Offset.ts';
+import type { Timestamp as _google_protobuf_Timestamp, Timestamp__Output as _google_protobuf_Timestamp__Output } from '../../google/protobuf/Timestamp.ts';
 
 // Original file: proto/source.proto
 
+/**
+ * Code to indicate the status of the response.
+ */
 export const _source_v1_ReadResponse_Status_Code = {
   SUCCESS: 'SUCCESS',
   FAILURE: 'FAILURE',
 } as const;
 
-export type _source_v1_ReadResponse_Status_Code = 'SUCCESS' | 0 | 'FAILURE' | 1;
+/**
+ * Code to indicate the status of the response.
+ */
+export type _source_v1_ReadResponse_Status_Code =
+  | 'SUCCESS'
+  | 0
+  | 'FAILURE'
+  | 1
 
-export type _source_v1_ReadResponse_Status_Code__Output =
-  (typeof _source_v1_ReadResponse_Status_Code)[keyof typeof _source_v1_ReadResponse_Status_Code];
+/**
+ * Code to indicate the status of the response.
+ */
+export type _source_v1_ReadResponse_Status_Code__Output = typeof _source_v1_ReadResponse_Status_Code[keyof typeof _source_v1_ReadResponse_Status_Code]
 
 // Original file: proto/source.proto
 
+/**
+ * Error to indicate the error type. If the code is FAILURE, then the error field will be populated.
+ */
 export const _source_v1_ReadResponse_Status_Error = {
   UNACKED: 'UNACKED',
   OTHER: 'OTHER',
 } as const;
 
-export type _source_v1_ReadResponse_Status_Error = 'UNACKED' | 0 | 'OTHER' | 1;
+/**
+ * Error to indicate the error type. If the code is FAILURE, then the error field will be populated.
+ */
+export type _source_v1_ReadResponse_Status_Error =
+  | 'UNACKED'
+  | 0
+  | 'OTHER'
+  | 1
 
-export type _source_v1_ReadResponse_Status_Error__Output =
-  (typeof _source_v1_ReadResponse_Status_Error)[keyof typeof _source_v1_ReadResponse_Status_Error];
+/**
+ * Error to indicate the error type. If the code is FAILURE, then the error field will be populated.
+ */
+export type _source_v1_ReadResponse_Status_Error__Output = typeof _source_v1_ReadResponse_Status_Error[keyof typeof _source_v1_ReadResponse_Status_Error]
 
 export interface _source_v1_ReadResponse_Result {
-  payload?: Buffer | Uint8Array | string;
-  offset?: _source_v1_Offset | null;
-  eventTime?: _google_protobuf_Timestamp | null;
-  keys?: string[];
-  headers?: { [key: string]: string };
+  /**
+   * Required field holding the payload of the datum.
+   */
+  'payload'?: (Buffer | Uint8Array | string);
+  /**
+   * Required field indicating the offset information of the datum.
+   */
+  'offset'?: (_source_v1_Offset | null);
+  /**
+   * Required field representing the time associated with each datum. It is used for watermarking.
+   */
+  'eventTime'?: (_google_protobuf_Timestamp | null);
+  /**
+   * Optional list of keys associated with the datum.
+   * Key is the "key" attribute in (key,value) as in the map-reduce paradigm.
+   * We add this optional field to support the use case where the user defined source can provide keys for the datum.
+   * e.g. Kafka and Redis Stream message usually include information about the keys.
+   */
+  'keys'?: (string)[];
+  /**
+   * Optional list of headers associated with the datum.
+   * Headers are the metadata associated with the datum.
+   * e.g. Kafka and Redis Stream message usually include information about the headers.
+   */
+  'headers'?: ({[key: string]: string});
 }
 
 export interface _source_v1_ReadResponse_Result__Output {
-  payload: Buffer;
-  offset: _source_v1_Offset__Output | null;
-  eventTime: _google_protobuf_Timestamp__Output | null;
-  keys: string[];
-  headers: { [key: string]: string };
+  /**
+   * Required field holding the payload of the datum.
+   */
+  'payload': (Buffer);
+  /**
+   * Required field indicating the offset information of the datum.
+   */
+  'offset': (_source_v1_Offset__Output | null);
+  /**
+   * Required field representing the time associated with each datum. It is used for watermarking.
+   */
+  'eventTime': (_google_protobuf_Timestamp__Output | null);
+  /**
+   * Optional list of keys associated with the datum.
+   * Key is the "key" attribute in (key,value) as in the map-reduce paradigm.
+   * We add this optional field to support the use case where the user defined source can provide keys for the datum.
+   * e.g. Kafka and Redis Stream message usually include information about the keys.
+   */
+  'keys': (string)[];
+  /**
+   * Optional list of headers associated with the datum.
+   * Headers are the metadata associated with the datum.
+   * e.g. Kafka and Redis Stream message usually include information about the headers.
+   */
+  'headers': ({[key: string]: string});
 }
 
 export interface _source_v1_ReadResponse_Status {
-  eot?: boolean;
-  code?: _source_v1_ReadResponse_Status_Code;
-  error?: _source_v1_ReadResponse_Status_Error;
-  msg?: string;
-  _error?: 'error';
-  _msg?: 'msg';
+  /**
+   * End of transmission flag.
+   */
+  'eot'?: (boolean);
+  'code'?: (_source_v1_ReadResponse_Status_Code);
+  'error'?: (_source_v1_ReadResponse_Status_Error);
+  'msg'?: (string);
+  '_error'?: "error";
+  '_msg'?: "msg";
 }
 
 export interface _source_v1_ReadResponse_Status__Output {
-  eot: boolean;
-  code: _source_v1_ReadResponse_Status_Code__Output;
-  error?: _source_v1_ReadResponse_Status_Error__Output;
-  msg?: string;
-  _error?: 'error';
-  _msg?: 'msg';
+  /**
+   * End of transmission flag.
+   */
+  'eot': (boolean);
+  'code': (_source_v1_ReadResponse_Status_Code__Output);
+  'error'?: (_source_v1_ReadResponse_Status_Error__Output);
+  'msg'?: (string);
+  '_error'?: "error";
+  '_msg'?: "msg";
 }
 
+/**
+ * ReadResponse is the response for reading datum stream from user defined source.
+ */
 export interface ReadResponse {
-  result?: _source_v1_ReadResponse_Result | null;
-  status?: _source_v1_ReadResponse_Status | null;
-  handshake?: _source_v1_Handshake | null;
-  _handshake?: 'handshake';
+  /**
+   * Required field holding the result.
+   */
+  'result'?: (_source_v1_ReadResponse_Result | null);
+  /**
+   * Status of the response. Holds the end of transmission flag and the status code.
+   */
+  'status'?: (_source_v1_ReadResponse_Status | null);
+  /**
+   * Handshake message between client and server to indicate the start of transmission.
+   */
+  'handshake'?: (_source_v1_Handshake | null);
+  '_handshake'?: "handshake";
 }
 
+/**
+ * ReadResponse is the response for reading datum stream from user defined source.
+ */
 export interface ReadResponse__Output {
-  result: _source_v1_ReadResponse_Result__Output | null;
-  status: _source_v1_ReadResponse_Status__Output | null;
-  handshake?: _source_v1_Handshake__Output | null;
-  _handshake?: 'handshake';
+  /**
+   * Required field holding the result.
+   */
+  'result': (_source_v1_ReadResponse_Result__Output | null);
+  /**
+   * Status of the response. Holds the end of transmission flag and the status code.
+   */
+  'status': (_source_v1_ReadResponse_Status__Output | null);
+  /**
+   * Handshake message between client and server to indicate the start of transmission.
+   */
+  'handshake'?: (_source_v1_Handshake__Output | null);
+  '_handshake'?: "handshake";
 }

--- a/src/source/proto/source/v1/ReadyResponse.ts
+++ b/src/source/proto/source/v1/ReadyResponse.ts
@@ -1,9 +1,22 @@
 // Original file: proto/source.proto
 
+
+/**
+ * ReadyResponse is the health check result for user defined source.
+ */
 export interface ReadyResponse {
-  ready?: boolean;
+  /**
+   * Required field holding the health check result.
+   */
+  'ready'?: (boolean);
 }
 
+/**
+ * ReadyResponse is the health check result for user defined source.
+ */
 export interface ReadyResponse__Output {
-  ready: boolean;
+  /**
+   * Required field holding the health check result.
+   */
+  'ready': (boolean);
 }

--- a/src/source/proto/source/v1/Source.ts
+++ b/src/source/proto/source/v1/Source.ts
@@ -1,228 +1,145 @@
 // Original file: proto/source.proto
 
-import type * as grpc from '@grpc/grpc-js';
-import type { MethodDefinition } from '@grpc/proto-loader';
-import type {
-  AckRequest as _source_v1_AckRequest,
-  AckRequest__Output as _source_v1_AckRequest__Output,
-} from '../../source/v1/AckRequest.ts';
-import type {
-  AckResponse as _source_v1_AckResponse,
-  AckResponse__Output as _source_v1_AckResponse__Output,
-} from '../../source/v1/AckResponse.ts';
-import type {
-  Empty as _google_protobuf_Empty,
-  Empty__Output as _google_protobuf_Empty__Output,
-} from '../../google/protobuf/Empty.ts';
-import type {
-  PartitionsResponse as _source_v1_PartitionsResponse,
-  PartitionsResponse__Output as _source_v1_PartitionsResponse__Output,
-} from '../../source/v1/PartitionsResponse.ts';
-import type {
-  PendingResponse as _source_v1_PendingResponse,
-  PendingResponse__Output as _source_v1_PendingResponse__Output,
-} from '../../source/v1/PendingResponse.ts';
-import type {
-  ReadRequest as _source_v1_ReadRequest,
-  ReadRequest__Output as _source_v1_ReadRequest__Output,
-} from '../../source/v1/ReadRequest.ts';
-import type {
-  ReadResponse as _source_v1_ReadResponse,
-  ReadResponse__Output as _source_v1_ReadResponse__Output,
-} from '../../source/v1/ReadResponse.ts';
-import type {
-  ReadyResponse as _source_v1_ReadyResponse,
-  ReadyResponse__Output as _source_v1_ReadyResponse__Output,
-} from '../../source/v1/ReadyResponse.ts';
+import type * as grpc from '@grpc/grpc-js'
+import type { MethodDefinition } from '@grpc/proto-loader'
+import type { AckRequest as _source_v1_AckRequest, AckRequest__Output as _source_v1_AckRequest__Output } from '../../source/v1/AckRequest.ts';
+import type { AckResponse as _source_v1_AckResponse, AckResponse__Output as _source_v1_AckResponse__Output } from '../../source/v1/AckResponse.ts';
+import type { Empty as _google_protobuf_Empty, Empty__Output as _google_protobuf_Empty__Output } from '../../google/protobuf/Empty.ts';
+import type { PartitionsResponse as _source_v1_PartitionsResponse, PartitionsResponse__Output as _source_v1_PartitionsResponse__Output } from '../../source/v1/PartitionsResponse.ts';
+import type { PendingResponse as _source_v1_PendingResponse, PendingResponse__Output as _source_v1_PendingResponse__Output } from '../../source/v1/PendingResponse.ts';
+import type { ReadRequest as _source_v1_ReadRequest, ReadRequest__Output as _source_v1_ReadRequest__Output } from '../../source/v1/ReadRequest.ts';
+import type { ReadResponse as _source_v1_ReadResponse, ReadResponse__Output as _source_v1_ReadResponse__Output } from '../../source/v1/ReadResponse.ts';
+import type { ReadyResponse as _source_v1_ReadyResponse, ReadyResponse__Output as _source_v1_ReadyResponse__Output } from '../../source/v1/ReadyResponse.ts';
 
 export interface SourceClient extends grpc.Client {
-  AckFn(
-    metadata: grpc.Metadata,
-    options?: grpc.CallOptions,
-  ): grpc.ClientDuplexStream<_source_v1_AckRequest, _source_v1_AckResponse__Output>;
+  /**
+   * AckFn acknowledges a stream of datum offsets.
+   * When AckFn is called, it implicitly indicates that the datum stream has been processed by the source vertex.
+   * The caller (numa) expects the AckFn to be successful, and it does not expect any errors.
+   * If there are some irrecoverable errors when the callee (UDSource) is processing the AckFn request,
+   * then it is best to crash because there are no other retry mechanisms possible.
+   * Clients sends n requests and expects n responses.
+   */
+  AckFn(metadata: grpc.Metadata, options?: grpc.CallOptions): grpc.ClientDuplexStream<_source_v1_AckRequest, _source_v1_AckResponse__Output>;
   AckFn(options?: grpc.CallOptions): grpc.ClientDuplexStream<_source_v1_AckRequest, _source_v1_AckResponse__Output>;
-  ackFn(
-    metadata: grpc.Metadata,
-    options?: grpc.CallOptions,
-  ): grpc.ClientDuplexStream<_source_v1_AckRequest, _source_v1_AckResponse__Output>;
+  /**
+   * AckFn acknowledges a stream of datum offsets.
+   * When AckFn is called, it implicitly indicates that the datum stream has been processed by the source vertex.
+   * The caller (numa) expects the AckFn to be successful, and it does not expect any errors.
+   * If there are some irrecoverable errors when the callee (UDSource) is processing the AckFn request,
+   * then it is best to crash because there are no other retry mechanisms possible.
+   * Clients sends n requests and expects n responses.
+   */
+  ackFn(metadata: grpc.Metadata, options?: grpc.CallOptions): grpc.ClientDuplexStream<_source_v1_AckRequest, _source_v1_AckResponse__Output>;
   ackFn(options?: grpc.CallOptions): grpc.ClientDuplexStream<_source_v1_AckRequest, _source_v1_AckResponse__Output>;
-
-  IsReady(
-    argument: _google_protobuf_Empty,
-    metadata: grpc.Metadata,
-    options: grpc.CallOptions,
-    callback: grpc.requestCallback<_source_v1_ReadyResponse__Output>,
-  ): grpc.ClientUnaryCall;
-  IsReady(
-    argument: _google_protobuf_Empty,
-    metadata: grpc.Metadata,
-    callback: grpc.requestCallback<_source_v1_ReadyResponse__Output>,
-  ): grpc.ClientUnaryCall;
-  IsReady(
-    argument: _google_protobuf_Empty,
-    options: grpc.CallOptions,
-    callback: grpc.requestCallback<_source_v1_ReadyResponse__Output>,
-  ): grpc.ClientUnaryCall;
-  IsReady(
-    argument: _google_protobuf_Empty,
-    callback: grpc.requestCallback<_source_v1_ReadyResponse__Output>,
-  ): grpc.ClientUnaryCall;
-  isReady(
-    argument: _google_protobuf_Empty,
-    metadata: grpc.Metadata,
-    options: grpc.CallOptions,
-    callback: grpc.requestCallback<_source_v1_ReadyResponse__Output>,
-  ): grpc.ClientUnaryCall;
-  isReady(
-    argument: _google_protobuf_Empty,
-    metadata: grpc.Metadata,
-    callback: grpc.requestCallback<_source_v1_ReadyResponse__Output>,
-  ): grpc.ClientUnaryCall;
-  isReady(
-    argument: _google_protobuf_Empty,
-    options: grpc.CallOptions,
-    callback: grpc.requestCallback<_source_v1_ReadyResponse__Output>,
-  ): grpc.ClientUnaryCall;
-  isReady(
-    argument: _google_protobuf_Empty,
-    callback: grpc.requestCallback<_source_v1_ReadyResponse__Output>,
-  ): grpc.ClientUnaryCall;
-
-  PartitionsFn(
-    argument: _google_protobuf_Empty,
-    metadata: grpc.Metadata,
-    options: grpc.CallOptions,
-    callback: grpc.requestCallback<_source_v1_PartitionsResponse__Output>,
-  ): grpc.ClientUnaryCall;
-  PartitionsFn(
-    argument: _google_protobuf_Empty,
-    metadata: grpc.Metadata,
-    callback: grpc.requestCallback<_source_v1_PartitionsResponse__Output>,
-  ): grpc.ClientUnaryCall;
-  PartitionsFn(
-    argument: _google_protobuf_Empty,
-    options: grpc.CallOptions,
-    callback: grpc.requestCallback<_source_v1_PartitionsResponse__Output>,
-  ): grpc.ClientUnaryCall;
-  PartitionsFn(
-    argument: _google_protobuf_Empty,
-    callback: grpc.requestCallback<_source_v1_PartitionsResponse__Output>,
-  ): grpc.ClientUnaryCall;
-  partitionsFn(
-    argument: _google_protobuf_Empty,
-    metadata: grpc.Metadata,
-    options: grpc.CallOptions,
-    callback: grpc.requestCallback<_source_v1_PartitionsResponse__Output>,
-  ): grpc.ClientUnaryCall;
-  partitionsFn(
-    argument: _google_protobuf_Empty,
-    metadata: grpc.Metadata,
-    callback: grpc.requestCallback<_source_v1_PartitionsResponse__Output>,
-  ): grpc.ClientUnaryCall;
-  partitionsFn(
-    argument: _google_protobuf_Empty,
-    options: grpc.CallOptions,
-    callback: grpc.requestCallback<_source_v1_PartitionsResponse__Output>,
-  ): grpc.ClientUnaryCall;
-  partitionsFn(
-    argument: _google_protobuf_Empty,
-    callback: grpc.requestCallback<_source_v1_PartitionsResponse__Output>,
-  ): grpc.ClientUnaryCall;
-
-  PendingFn(
-    argument: _google_protobuf_Empty,
-    metadata: grpc.Metadata,
-    options: grpc.CallOptions,
-    callback: grpc.requestCallback<_source_v1_PendingResponse__Output>,
-  ): grpc.ClientUnaryCall;
-  PendingFn(
-    argument: _google_protobuf_Empty,
-    metadata: grpc.Metadata,
-    callback: grpc.requestCallback<_source_v1_PendingResponse__Output>,
-  ): grpc.ClientUnaryCall;
-  PendingFn(
-    argument: _google_protobuf_Empty,
-    options: grpc.CallOptions,
-    callback: grpc.requestCallback<_source_v1_PendingResponse__Output>,
-  ): grpc.ClientUnaryCall;
-  PendingFn(
-    argument: _google_protobuf_Empty,
-    callback: grpc.requestCallback<_source_v1_PendingResponse__Output>,
-  ): grpc.ClientUnaryCall;
-  pendingFn(
-    argument: _google_protobuf_Empty,
-    metadata: grpc.Metadata,
-    options: grpc.CallOptions,
-    callback: grpc.requestCallback<_source_v1_PendingResponse__Output>,
-  ): grpc.ClientUnaryCall;
-  pendingFn(
-    argument: _google_protobuf_Empty,
-    metadata: grpc.Metadata,
-    callback: grpc.requestCallback<_source_v1_PendingResponse__Output>,
-  ): grpc.ClientUnaryCall;
-  pendingFn(
-    argument: _google_protobuf_Empty,
-    options: grpc.CallOptions,
-    callback: grpc.requestCallback<_source_v1_PendingResponse__Output>,
-  ): grpc.ClientUnaryCall;
-  pendingFn(
-    argument: _google_protobuf_Empty,
-    callback: grpc.requestCallback<_source_v1_PendingResponse__Output>,
-  ): grpc.ClientUnaryCall;
-
-  ReadFn(
-    metadata: grpc.Metadata,
-    options?: grpc.CallOptions,
-  ): grpc.ClientDuplexStream<_source_v1_ReadRequest, _source_v1_ReadResponse__Output>;
+  
+  /**
+   * IsReady is the heartbeat endpoint for user defined source gRPC.
+   */
+  IsReady(argument: _google_protobuf_Empty, metadata: grpc.Metadata, options: grpc.CallOptions, callback: grpc.requestCallback<_source_v1_ReadyResponse__Output>): grpc.ClientUnaryCall;
+  IsReady(argument: _google_protobuf_Empty, metadata: grpc.Metadata, callback: grpc.requestCallback<_source_v1_ReadyResponse__Output>): grpc.ClientUnaryCall;
+  IsReady(argument: _google_protobuf_Empty, options: grpc.CallOptions, callback: grpc.requestCallback<_source_v1_ReadyResponse__Output>): grpc.ClientUnaryCall;
+  IsReady(argument: _google_protobuf_Empty, callback: grpc.requestCallback<_source_v1_ReadyResponse__Output>): grpc.ClientUnaryCall;
+  /**
+   * IsReady is the heartbeat endpoint for user defined source gRPC.
+   */
+  isReady(argument: _google_protobuf_Empty, metadata: grpc.Metadata, options: grpc.CallOptions, callback: grpc.requestCallback<_source_v1_ReadyResponse__Output>): grpc.ClientUnaryCall;
+  isReady(argument: _google_protobuf_Empty, metadata: grpc.Metadata, callback: grpc.requestCallback<_source_v1_ReadyResponse__Output>): grpc.ClientUnaryCall;
+  isReady(argument: _google_protobuf_Empty, options: grpc.CallOptions, callback: grpc.requestCallback<_source_v1_ReadyResponse__Output>): grpc.ClientUnaryCall;
+  isReady(argument: _google_protobuf_Empty, callback: grpc.requestCallback<_source_v1_ReadyResponse__Output>): grpc.ClientUnaryCall;
+  
+  /**
+   * PartitionsFn returns the list of partitions for the user defined source.
+   */
+  PartitionsFn(argument: _google_protobuf_Empty, metadata: grpc.Metadata, options: grpc.CallOptions, callback: grpc.requestCallback<_source_v1_PartitionsResponse__Output>): grpc.ClientUnaryCall;
+  PartitionsFn(argument: _google_protobuf_Empty, metadata: grpc.Metadata, callback: grpc.requestCallback<_source_v1_PartitionsResponse__Output>): grpc.ClientUnaryCall;
+  PartitionsFn(argument: _google_protobuf_Empty, options: grpc.CallOptions, callback: grpc.requestCallback<_source_v1_PartitionsResponse__Output>): grpc.ClientUnaryCall;
+  PartitionsFn(argument: _google_protobuf_Empty, callback: grpc.requestCallback<_source_v1_PartitionsResponse__Output>): grpc.ClientUnaryCall;
+  /**
+   * PartitionsFn returns the list of partitions for the user defined source.
+   */
+  partitionsFn(argument: _google_protobuf_Empty, metadata: grpc.Metadata, options: grpc.CallOptions, callback: grpc.requestCallback<_source_v1_PartitionsResponse__Output>): grpc.ClientUnaryCall;
+  partitionsFn(argument: _google_protobuf_Empty, metadata: grpc.Metadata, callback: grpc.requestCallback<_source_v1_PartitionsResponse__Output>): grpc.ClientUnaryCall;
+  partitionsFn(argument: _google_protobuf_Empty, options: grpc.CallOptions, callback: grpc.requestCallback<_source_v1_PartitionsResponse__Output>): grpc.ClientUnaryCall;
+  partitionsFn(argument: _google_protobuf_Empty, callback: grpc.requestCallback<_source_v1_PartitionsResponse__Output>): grpc.ClientUnaryCall;
+  
+  /**
+   * PendingFn returns the number of pending records at the user defined source.
+   */
+  PendingFn(argument: _google_protobuf_Empty, metadata: grpc.Metadata, options: grpc.CallOptions, callback: grpc.requestCallback<_source_v1_PendingResponse__Output>): grpc.ClientUnaryCall;
+  PendingFn(argument: _google_protobuf_Empty, metadata: grpc.Metadata, callback: grpc.requestCallback<_source_v1_PendingResponse__Output>): grpc.ClientUnaryCall;
+  PendingFn(argument: _google_protobuf_Empty, options: grpc.CallOptions, callback: grpc.requestCallback<_source_v1_PendingResponse__Output>): grpc.ClientUnaryCall;
+  PendingFn(argument: _google_protobuf_Empty, callback: grpc.requestCallback<_source_v1_PendingResponse__Output>): grpc.ClientUnaryCall;
+  /**
+   * PendingFn returns the number of pending records at the user defined source.
+   */
+  pendingFn(argument: _google_protobuf_Empty, metadata: grpc.Metadata, options: grpc.CallOptions, callback: grpc.requestCallback<_source_v1_PendingResponse__Output>): grpc.ClientUnaryCall;
+  pendingFn(argument: _google_protobuf_Empty, metadata: grpc.Metadata, callback: grpc.requestCallback<_source_v1_PendingResponse__Output>): grpc.ClientUnaryCall;
+  pendingFn(argument: _google_protobuf_Empty, options: grpc.CallOptions, callback: grpc.requestCallback<_source_v1_PendingResponse__Output>): grpc.ClientUnaryCall;
+  pendingFn(argument: _google_protobuf_Empty, callback: grpc.requestCallback<_source_v1_PendingResponse__Output>): grpc.ClientUnaryCall;
+  
+  /**
+   * Read returns a stream of datum responses.
+   * The size of the returned responses is less than or equal to the num_records specified in each ReadRequest.
+   * If the request timeout is reached on the server side, the returned responses will contain all the datum that have been read (which could be an empty list).
+   * The server will continue to read and respond to subsequent ReadRequests until the client closes the stream.
+   * Once it has sent all the datum, the server will send a ReadResponse with the end of transmission flag set to true.
+   */
+  ReadFn(metadata: grpc.Metadata, options?: grpc.CallOptions): grpc.ClientDuplexStream<_source_v1_ReadRequest, _source_v1_ReadResponse__Output>;
   ReadFn(options?: grpc.CallOptions): grpc.ClientDuplexStream<_source_v1_ReadRequest, _source_v1_ReadResponse__Output>;
-  readFn(
-    metadata: grpc.Metadata,
-    options?: grpc.CallOptions,
-  ): grpc.ClientDuplexStream<_source_v1_ReadRequest, _source_v1_ReadResponse__Output>;
+  /**
+   * Read returns a stream of datum responses.
+   * The size of the returned responses is less than or equal to the num_records specified in each ReadRequest.
+   * If the request timeout is reached on the server side, the returned responses will contain all the datum that have been read (which could be an empty list).
+   * The server will continue to read and respond to subsequent ReadRequests until the client closes the stream.
+   * Once it has sent all the datum, the server will send a ReadResponse with the end of transmission flag set to true.
+   */
+  readFn(metadata: grpc.Metadata, options?: grpc.CallOptions): grpc.ClientDuplexStream<_source_v1_ReadRequest, _source_v1_ReadResponse__Output>;
   readFn(options?: grpc.CallOptions): grpc.ClientDuplexStream<_source_v1_ReadRequest, _source_v1_ReadResponse__Output>;
+  
 }
 
 export interface SourceHandlers extends grpc.UntypedServiceImplementation {
+  /**
+   * AckFn acknowledges a stream of datum offsets.
+   * When AckFn is called, it implicitly indicates that the datum stream has been processed by the source vertex.
+   * The caller (numa) expects the AckFn to be successful, and it does not expect any errors.
+   * If there are some irrecoverable errors when the callee (UDSource) is processing the AckFn request,
+   * then it is best to crash because there are no other retry mechanisms possible.
+   * Clients sends n requests and expects n responses.
+   */
   AckFn: grpc.handleBidiStreamingCall<_source_v1_AckRequest__Output, _source_v1_AckResponse>;
-
+  
+  /**
+   * IsReady is the heartbeat endpoint for user defined source gRPC.
+   */
   IsReady: grpc.handleUnaryCall<_google_protobuf_Empty__Output, _source_v1_ReadyResponse>;
-
+  
+  /**
+   * PartitionsFn returns the list of partitions for the user defined source.
+   */
   PartitionsFn: grpc.handleUnaryCall<_google_protobuf_Empty__Output, _source_v1_PartitionsResponse>;
-
+  
+  /**
+   * PendingFn returns the number of pending records at the user defined source.
+   */
   PendingFn: grpc.handleUnaryCall<_google_protobuf_Empty__Output, _source_v1_PendingResponse>;
-
+  
+  /**
+   * Read returns a stream of datum responses.
+   * The size of the returned responses is less than or equal to the num_records specified in each ReadRequest.
+   * If the request timeout is reached on the server side, the returned responses will contain all the datum that have been read (which could be an empty list).
+   * The server will continue to read and respond to subsequent ReadRequests until the client closes the stream.
+   * Once it has sent all the datum, the server will send a ReadResponse with the end of transmission flag set to true.
+   */
   ReadFn: grpc.handleBidiStreamingCall<_source_v1_ReadRequest__Output, _source_v1_ReadResponse>;
+  
 }
 
 export interface SourceDefinition extends grpc.ServiceDefinition {
-  AckFn: MethodDefinition<
-    _source_v1_AckRequest,
-    _source_v1_AckResponse,
-    _source_v1_AckRequest__Output,
-    _source_v1_AckResponse__Output
-  >;
-  IsReady: MethodDefinition<
-    _google_protobuf_Empty,
-    _source_v1_ReadyResponse,
-    _google_protobuf_Empty__Output,
-    _source_v1_ReadyResponse__Output
-  >;
-  PartitionsFn: MethodDefinition<
-    _google_protobuf_Empty,
-    _source_v1_PartitionsResponse,
-    _google_protobuf_Empty__Output,
-    _source_v1_PartitionsResponse__Output
-  >;
-  PendingFn: MethodDefinition<
-    _google_protobuf_Empty,
-    _source_v1_PendingResponse,
-    _google_protobuf_Empty__Output,
-    _source_v1_PendingResponse__Output
-  >;
-  ReadFn: MethodDefinition<
-    _source_v1_ReadRequest,
-    _source_v1_ReadResponse,
-    _source_v1_ReadRequest__Output,
-    _source_v1_ReadResponse__Output
-  >;
+  AckFn: MethodDefinition<_source_v1_AckRequest, _source_v1_AckResponse, _source_v1_AckRequest__Output, _source_v1_AckResponse__Output>
+  IsReady: MethodDefinition<_google_protobuf_Empty, _source_v1_ReadyResponse, _google_protobuf_Empty__Output, _source_v1_ReadyResponse__Output>
+  PartitionsFn: MethodDefinition<_google_protobuf_Empty, _source_v1_PartitionsResponse, _google_protobuf_Empty__Output, _source_v1_PartitionsResponse__Output>
+  PendingFn: MethodDefinition<_google_protobuf_Empty, _source_v1_PendingResponse, _google_protobuf_Empty__Output, _source_v1_PendingResponse__Output>
+  ReadFn: MethodDefinition<_source_v1_ReadRequest, _source_v1_ReadResponse, _source_v1_ReadRequest__Output, _source_v1_ReadResponse__Output>
 }

--- a/src/source/types.ts
+++ b/src/source/types.ts
@@ -1,33 +1,33 @@
 import { Buffer } from 'buffer';
 
 export type ReadRequest = {
-  count: number;
-  timeout_ms: number;
+    count: number;
+    timeout_ms: number;
 };
 
 export type Offset = {
-  value: Buffer;
-  partitionId: number;
+    value: Buffer;
+    partitionId: number;
 };
 
 export type Message = {
-  value: Buffer;
-  offset: Offset;
-  eventTime: Date;
-  keys?: string[];
-  headers?: Map<string, string>;
+    value: Buffer;
+    offset: Offset;
+    eventTime: Date;
+    keys?: string[];
+    headers?: Map<string, string>;
 };
 
 export interface Sourcer {
-  read(readRequest: ReadRequest): Promise<Message[]>;
-  ack(offsets: Offset[]): Promise<void>;
-  pending(): Promise<number>;
-  partitions(): Promise<number[]>;
+    read(readRequest: ReadRequest): Promise<Message[]>;
+    ack(offsets: Offset[]): Promise<void>;
+    pending(): Promise<number>;
+    partitions(): Promise<number[]>;
 }
 
 export function createOffsetWithDefaultPartitionId(value: Buffer | string): Offset {
-  return {
-    value: Buffer.isBuffer(value) ? value : Buffer.from(value),
-    partitionId: +(process.env['NUMAFLOW_REPLICA'] ?? 0),
-  };
+    return {
+        value: Buffer.isBuffer(value) ? value : Buffer.from(value),
+        partitionId: +(process.env['NUMAFLOW_REPLICA'] ?? 0),
+    };
 }

--- a/src/sourcetransformer/index.ts
+++ b/src/sourcetransformer/index.ts
@@ -13,179 +13,179 @@ import { parseServerOptions } from '../common/server.js';
 import { ContainerTypes, MinimumNumaflowVersions, MSG_DROP_TAG } from '../common/constants.js';
 
 const Paths = {
-  SOCKET_PATH: '/var/run/numaflow/sourcetransform.sock',
-  SERVER_INFO_FILE_PATH: '/var/run/numaflow/sourcetransformer-server-info',
+    SOCKET_PATH: '/var/run/numaflow/sourcetransform.sock',
+    SERVER_INFO_FILE_PATH: '/var/run/numaflow/sourcetransformer-server-info',
 };
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 export function messageToDrop(eventTime: Date): Message {
-  return { eventTime, tags: [MSG_DROP_TAG] };
+    return { eventTime, tags: [MSG_DROP_TAG] };
 }
 
 export interface Datum {
-  value: Buffer;
-  eventTime: Date;
-  watermark: Date;
-  headers: Map<string, string>;
+    value: Buffer;
+    eventTime: Date;
+    watermark: Date;
+    headers: Map<string, string>;
 }
 
 export type Message = {
-  value?: Buffer;
-  keys?: string[];
-  tags?: string[];
-  eventTime: Date;
+    value?: Buffer;
+    keys?: string[];
+    tags?: string[];
+    eventTime: Date;
 };
 
 export interface SourceTransformer {
-  transform(keys: string[], datum: Datum): Promise<Message[]>;
+    transform(keys: string[], datum: Datum): Promise<Message[]>;
 }
 
 class SourceTransformService {
-  constructor(
-    private transformer: SourceTransformer,
-    private opts: ServerOpts,
-  ) {}
+    constructor(
+        private transformer: SourceTransformer,
+        private opts: ServerOpts,
+    ) {}
 
-  start(this: SourceTransformService) {
-    const packageDef = protoLoader.loadSync(path.join(__dirname, '../../proto/sourcetransformer.proto'), {});
-    const proto = grpc.loadPackageDefinition(packageDef) as unknown as ProtoGrpcType;
-    const serverInfo: ServerInfo = {
-      ...DEFAULT_SERVER_INFO,
-      minimum_numaflow_version: MinimumNumaflowVersions[ContainerTypes.Sourcetransformer],
-    };
-    prepareServer(serverInfo, Paths.SERVER_INFO_FILE_PATH, Paths.SOCKET_PATH);
-
-    const transformServer: SourceTransformHandlers = {
-      IsReady: this.isReady.bind(this),
-      SourceTransformFn: this.sourceTransformFn.bind(this),
-    };
-
-    const server = new grpc.Server({
-      'grpc.max_send_message_length': this.opts.grpcMaxMessageSizeBytes,
-      'grpc.max_receive_message_length': this.opts.grpcMaxMessageSizeBytes,
-    });
-    server.addService(proto.sourcetransformer.v1.SourceTransform.service, transformServer);
-    server.bindAsync(`unix://${Paths.SOCKET_PATH}`, grpc.ServerCredentials.createInsecure(), (err) => {
-      if (err) {
-        console.error('Failed to bind server:', err.message);
-        return;
-      }
-      console.log('Server bound successfully. Starting server...');
-    });
-  }
-
-  isReady(
-    this: SourceTransformService,
-    _call: grpc.ServerUnaryCall<Empty, ReadyResponse>,
-    callback: grpc.sendUnaryData<ReadyResponse>,
-  ) {
-    console.log(`Received isReady request`);
-    return callback(null, { ready: true });
-  }
-
-  private sourceTransformFn(
-    this: SourceTransformService,
-    call: grpc.ServerDuplexStream<SourceTransformRequest, SourceTransformResponse>,
-  ) {
-    console.log('SourceTransformFn called');
-    let handshakeDone = false;
-    call.on('data', async (request: SourceTransformRequest) => {
-      if (!handshakeDone) {
-        if (!request.handshake?.sot) {
-          console.error('Expected handshake message');
-        }
-        handshakeDone = true;
-        call.write({ handshake: { sot: true } });
-        console.log('Handshake completed');
-        return;
-      }
-      if (request.request) {
-        const keys = request.request.keys ?? [];
-        const datum = this.createDatumFromRequest(request);
-        const transformedValues = await this.transformer.transform(keys, datum);
-        if (transformedValues.length === 0) {
-          console.error(`Transform response cannot be empty. message_id=${request.request.id}`);
-        }
-        const response: SourceTransformResponse = {
-          id: request.request.id,
-          results: [],
+    start(this: SourceTransformService) {
+        const packageDef = protoLoader.loadSync(path.join(__dirname, '../../proto/sourcetransformer.proto'), {});
+        const proto = grpc.loadPackageDefinition(packageDef) as unknown as ProtoGrpcType;
+        const serverInfo: ServerInfo = {
+            ...DEFAULT_SERVER_INFO,
+            minimum_numaflow_version: MinimumNumaflowVersions[ContainerTypes.Sourcetransformer],
         };
-        for (const msg of transformedValues) {
-          response.results?.push({
-            ...msg,
-            eventTime: msg.eventTime ? { seconds: Math.floor(msg.eventTime.getTime() / 1000) } : undefined,
-          });
+        prepareServer(serverInfo, Paths.SERVER_INFO_FILE_PATH, Paths.SOCKET_PATH);
+
+        const transformServer: SourceTransformHandlers = {
+            IsReady: this.isReady.bind(this),
+            SourceTransformFn: this.sourceTransformFn.bind(this),
+        };
+
+        const server = new grpc.Server({
+            'grpc.max_send_message_length': this.opts.grpcMaxMessageSizeBytes,
+            'grpc.max_receive_message_length': this.opts.grpcMaxMessageSizeBytes,
+        });
+        server.addService(proto.sourcetransformer.v1.SourceTransform.service, transformServer);
+        server.bindAsync(`unix://${Paths.SOCKET_PATH}`, grpc.ServerCredentials.createInsecure(), (err) => {
+            if (err) {
+                console.error('Failed to bind server:', err.message);
+                return;
+            }
+            console.log('Server bound successfully. Starting server...');
+        });
+    }
+
+    isReady(
+        this: SourceTransformService,
+        _call: grpc.ServerUnaryCall<Empty, ReadyResponse>,
+        callback: grpc.sendUnaryData<ReadyResponse>,
+    ) {
+        console.log(`Received isReady request`);
+        return callback(null, { ready: true });
+    }
+
+    private sourceTransformFn(
+        this: SourceTransformService,
+        call: grpc.ServerDuplexStream<SourceTransformRequest, SourceTransformResponse>,
+    ) {
+        console.log('SourceTransformFn called');
+        let handshakeDone = false;
+        call.on('data', async (request: SourceTransformRequest) => {
+            if (!handshakeDone) {
+                if (!request.handshake?.sot) {
+                    console.error('Expected handshake message');
+                }
+                handshakeDone = true;
+                call.write({ handshake: { sot: true } });
+                console.log('Handshake completed');
+                return;
+            }
+            if (request.request) {
+                const keys = request.request.keys ?? [];
+                const datum = this.createDatumFromRequest(request);
+                const transformedValues = await this.transformer.transform(keys, datum);
+                if (transformedValues.length === 0) {
+                    console.error(`Transform response cannot be empty. message_id=${request.request.id}`);
+                }
+                const response: SourceTransformResponse = {
+                    id: request.request.id,
+                    results: [],
+                };
+                for (const msg of transformedValues) {
+                    response.results?.push({
+                        ...msg,
+                        eventTime: msg.eventTime ? { seconds: Math.floor(msg.eventTime.getTime() / 1000) } : undefined,
+                    });
+                }
+                call.write(response);
+                return;
+            }
+            console.log(`Invalid Source request: ${JSON.stringify(request, null, 2)}`);
+            throw { message: `invalid request: ${request}` };
+        });
+
+        call.on('end', () => {
+            console.log('Stream ended');
+            call.end(); // End the stream
+        });
+    }
+
+    private createDatumFromRequest(request: SourceTransformRequest): Datum {
+        const buf = request.request?.value ?? '';
+        const payload = typeof buf === 'string' ? Buffer.from(buf) : Buffer.from(buf);
+
+        const et = request.request?.eventTime ?? new Date();
+        let eventTimeResponse: Date;
+        if (et instanceof Date) {
+            eventTimeResponse = et;
+        } else {
+            // FIXME: handle nanoseconds field in Timestamp
+            let seconds: number;
+            if (typeof et.seconds === 'string') {
+                seconds = parseInt(et.seconds, 10);
+            } else if (typeof et.seconds === 'object' && 'toNumber' in et.seconds) {
+                seconds = et.seconds.toNumber();
+            } else {
+                seconds = et.seconds as number;
+            }
+            eventTimeResponse = new Date(seconds * 1000);
         }
-        call.write(response);
-        return;
-      }
-      console.log(`Invalid Source request: ${JSON.stringify(request, null, 2)}`);
-      throw { message: `invalid request: ${request}` };
-    });
 
-    call.on('end', () => {
-      console.log('Stream ended');
-      call.end(); // End the stream
-    });
-  }
+        const wt = request.request?.watermark ?? new Date();
+        let watermarkResponse: Date;
+        if (wt instanceof Date) {
+            watermarkResponse = wt;
+        } else {
+            // FIXME: handle nanoseconds field in Timestamp
+            let seconds: number;
+            if (typeof wt.seconds === 'string') {
+                seconds = parseInt(wt.seconds, 10);
+            } else if (typeof wt.seconds === 'object' && 'toNumber' in wt.seconds) {
+                seconds = wt.seconds.toNumber();
+            } else {
+                seconds = wt.seconds as number;
+            }
+            watermarkResponse = new Date(seconds * 1000);
+        }
 
-  private createDatumFromRequest(request: SourceTransformRequest): Datum {
-    const buf = request.request?.value ?? '';
-    const payload = typeof buf === 'string' ? Buffer.from(buf) : Buffer.from(buf);
+        const headersObj = request.request?.headers ?? {};
+        const headersMap = new Map<string, string>();
 
-    const et = request.request?.eventTime ?? new Date();
-    let eventTimeResponse: Date;
-    if (et instanceof Date) {
-      eventTimeResponse = et;
-    } else {
-      // FIXME: handle nanoseconds field in Timestamp
-      let seconds: number;
-      if (typeof et.seconds === 'string') {
-        seconds = parseInt(et.seconds, 10);
-      } else if (typeof et.seconds === 'object' && 'toNumber' in et.seconds) {
-        seconds = et.seconds.toNumber();
-      } else {
-        seconds = et.seconds as number;
-      }
-      eventTimeResponse = new Date(seconds * 1000);
+        for (const [key, value] of Object.entries(headersObj)) {
+            headersMap.set(key, value);
+        }
+
+        return {
+            value: payload,
+            eventTime: eventTimeResponse,
+            watermark: watermarkResponse,
+            headers: headersMap,
+        };
     }
-
-    const wt = request.request?.watermark ?? new Date();
-    let watermarkResponse: Date;
-    if (wt instanceof Date) {
-      watermarkResponse = wt;
-    } else {
-      // FIXME: handle nanoseconds field in Timestamp
-      let seconds: number;
-      if (typeof wt.seconds === 'string') {
-        seconds = parseInt(wt.seconds, 10);
-      } else if (typeof wt.seconds === 'object' && 'toNumber' in wt.seconds) {
-        seconds = wt.seconds.toNumber();
-      } else {
-        seconds = wt.seconds as number;
-      }
-      watermarkResponse = new Date(seconds * 1000);
-    }
-
-    const headersObj = request.request?.headers ?? {};
-    const headersMap = new Map<string, string>();
-
-    for (const [key, value] of Object.entries(headersObj)) {
-      headersMap.set(key, value);
-    }
-
-    return {
-      value: payload,
-      eventTime: eventTimeResponse,
-      watermark: watermarkResponse,
-      headers: headersMap,
-    };
-  }
 }
 
 export function createServer(transformer: SourceTransformer, options?: ServerOpts): SourceTransformService {
-  const opts = parseServerOptions(options);
-  return new SourceTransformService(transformer, opts);
+    const opts = parseServerOptions(options);
+    return new SourceTransformService(transformer, opts);
 }

--- a/src/sourcetransformer/proto/google/protobuf/Empty.ts
+++ b/src/sourcetransformer/proto/google/protobuf/Empty.ts
@@ -1,5 +1,8 @@
 // Original file: null
 
-export interface Empty {}
 
-export interface Empty__Output {}
+export interface Empty {
+}
+
+export interface Empty__Output {
+}

--- a/src/sourcetransformer/proto/google/protobuf/Timestamp.ts
+++ b/src/sourcetransformer/proto/google/protobuf/Timestamp.ts
@@ -3,11 +3,11 @@
 import type { Long } from '@grpc/proto-loader';
 
 export interface Timestamp {
-  seconds?: number | string | Long;
-  nanos?: number;
+  'seconds'?: (number | string | Long);
+  'nanos'?: (number);
 }
 
 export interface Timestamp__Output {
-  seconds: string;
-  nanos: number;
+  'seconds': (string);
+  'nanos': (number);
 }

--- a/src/sourcetransformer/proto/sourcetransformer.ts
+++ b/src/sourcetransformer/proto/sourcetransformer.ts
@@ -1,31 +1,27 @@
 import type * as grpc from '@grpc/grpc-js';
 import type { MessageTypeDefinition } from '@grpc/proto-loader';
 
-import type {
-  SourceTransformClient as _sourcetransformer_v1_SourceTransformClient,
-  SourceTransformDefinition as _sourcetransformer_v1_SourceTransformDefinition,
-} from './sourcetransformer/v1/SourceTransform.ts';
+import type { SourceTransformClient as _sourcetransformer_v1_SourceTransformClient, SourceTransformDefinition as _sourcetransformer_v1_SourceTransformDefinition } from './sourcetransformer/v1/SourceTransform.ts';
 
 type SubtypeConstructor<Constructor extends new (...args: any) => any, Subtype> = {
-  new (...args: ConstructorParameters<Constructor>): Subtype;
+  new(...args: ConstructorParameters<Constructor>): Subtype;
 };
 
 export interface ProtoGrpcType {
   google: {
     protobuf: {
-      Empty: MessageTypeDefinition;
-      Timestamp: MessageTypeDefinition;
-    };
-  };
+      Empty: MessageTypeDefinition
+      Timestamp: MessageTypeDefinition
+    }
+  }
   sourcetransformer: {
     v1: {
-      Handshake: MessageTypeDefinition;
-      ReadyResponse: MessageTypeDefinition;
-      SourceTransform: SubtypeConstructor<typeof grpc.Client, _sourcetransformer_v1_SourceTransformClient> & {
-        service: _sourcetransformer_v1_SourceTransformDefinition;
-      };
-      SourceTransformRequest: MessageTypeDefinition;
-      SourceTransformResponse: MessageTypeDefinition;
-    };
-  };
+      Handshake: MessageTypeDefinition
+      ReadyResponse: MessageTypeDefinition
+      SourceTransform: SubtypeConstructor<typeof grpc.Client, _sourcetransformer_v1_SourceTransformClient> & { service: _sourcetransformer_v1_SourceTransformDefinition }
+      SourceTransformRequest: MessageTypeDefinition
+      SourceTransformResponse: MessageTypeDefinition
+    }
+  }
 }
+

--- a/src/sourcetransformer/proto/sourcetransformer/v1/Handshake.ts
+++ b/src/sourcetransformer/proto/sourcetransformer/v1/Handshake.ts
@@ -1,9 +1,22 @@
 // Original file: proto/sourcetransformer.proto
 
+
+/**
+ * Handshake message between client and server to indicate the start of transmission.
+ */
 export interface Handshake {
-  sot?: boolean;
+  /**
+   * Required field indicating the start of transmission.
+   */
+  'sot'?: (boolean);
 }
 
+/**
+ * Handshake message between client and server to indicate the start of transmission.
+ */
 export interface Handshake__Output {
-  sot: boolean;
+  /**
+   * Required field indicating the start of transmission.
+   */
+  'sot': (boolean);
 }

--- a/src/sourcetransformer/proto/sourcetransformer/v1/ReadyResponse.ts
+++ b/src/sourcetransformer/proto/sourcetransformer/v1/ReadyResponse.ts
@@ -1,9 +1,16 @@
 // Original file: proto/sourcetransformer.proto
 
+
+/**
+ * ReadyResponse is the health check result.
+ */
 export interface ReadyResponse {
-  ready?: boolean;
+  'ready'?: (boolean);
 }
 
+/**
+ * ReadyResponse is the health check result.
+ */
 export interface ReadyResponse__Output {
-  ready: boolean;
+  'ready': (boolean);
 }

--- a/src/sourcetransformer/proto/sourcetransformer/v1/SourceTransform.ts
+++ b/src/sourcetransformer/proto/sourcetransformer/v1/SourceTransform.ts
@@ -1,114 +1,61 @@
 // Original file: proto/sourcetransformer.proto
 
-import type * as grpc from '@grpc/grpc-js';
-import type { MethodDefinition } from '@grpc/proto-loader';
-import type {
-  Empty as _google_protobuf_Empty,
-  Empty__Output as _google_protobuf_Empty__Output,
-} from '../../google/protobuf/Empty.ts';
-import type {
-  ReadyResponse as _sourcetransformer_v1_ReadyResponse,
-  ReadyResponse__Output as _sourcetransformer_v1_ReadyResponse__Output,
-} from '../../sourcetransformer/v1/ReadyResponse.ts';
-import type {
-  SourceTransformRequest as _sourcetransformer_v1_SourceTransformRequest,
-  SourceTransformRequest__Output as _sourcetransformer_v1_SourceTransformRequest__Output,
-} from '../../sourcetransformer/v1/SourceTransformRequest.ts';
-import type {
-  SourceTransformResponse as _sourcetransformer_v1_SourceTransformResponse,
-  SourceTransformResponse__Output as _sourcetransformer_v1_SourceTransformResponse__Output,
-} from '../../sourcetransformer/v1/SourceTransformResponse.ts';
+import type * as grpc from '@grpc/grpc-js'
+import type { MethodDefinition } from '@grpc/proto-loader'
+import type { Empty as _google_protobuf_Empty, Empty__Output as _google_protobuf_Empty__Output } from '../../google/protobuf/Empty.ts';
+import type { ReadyResponse as _sourcetransformer_v1_ReadyResponse, ReadyResponse__Output as _sourcetransformer_v1_ReadyResponse__Output } from '../../sourcetransformer/v1/ReadyResponse.ts';
+import type { SourceTransformRequest as _sourcetransformer_v1_SourceTransformRequest, SourceTransformRequest__Output as _sourcetransformer_v1_SourceTransformRequest__Output } from '../../sourcetransformer/v1/SourceTransformRequest.ts';
+import type { SourceTransformResponse as _sourcetransformer_v1_SourceTransformResponse, SourceTransformResponse__Output as _sourcetransformer_v1_SourceTransformResponse__Output } from '../../sourcetransformer/v1/SourceTransformResponse.ts';
 
 export interface SourceTransformClient extends grpc.Client {
-  IsReady(
-    argument: _google_protobuf_Empty,
-    metadata: grpc.Metadata,
-    options: grpc.CallOptions,
-    callback: grpc.requestCallback<_sourcetransformer_v1_ReadyResponse__Output>,
-  ): grpc.ClientUnaryCall;
-  IsReady(
-    argument: _google_protobuf_Empty,
-    metadata: grpc.Metadata,
-    callback: grpc.requestCallback<_sourcetransformer_v1_ReadyResponse__Output>,
-  ): grpc.ClientUnaryCall;
-  IsReady(
-    argument: _google_protobuf_Empty,
-    options: grpc.CallOptions,
-    callback: grpc.requestCallback<_sourcetransformer_v1_ReadyResponse__Output>,
-  ): grpc.ClientUnaryCall;
-  IsReady(
-    argument: _google_protobuf_Empty,
-    callback: grpc.requestCallback<_sourcetransformer_v1_ReadyResponse__Output>,
-  ): grpc.ClientUnaryCall;
-  isReady(
-    argument: _google_protobuf_Empty,
-    metadata: grpc.Metadata,
-    options: grpc.CallOptions,
-    callback: grpc.requestCallback<_sourcetransformer_v1_ReadyResponse__Output>,
-  ): grpc.ClientUnaryCall;
-  isReady(
-    argument: _google_protobuf_Empty,
-    metadata: grpc.Metadata,
-    callback: grpc.requestCallback<_sourcetransformer_v1_ReadyResponse__Output>,
-  ): grpc.ClientUnaryCall;
-  isReady(
-    argument: _google_protobuf_Empty,
-    options: grpc.CallOptions,
-    callback: grpc.requestCallback<_sourcetransformer_v1_ReadyResponse__Output>,
-  ): grpc.ClientUnaryCall;
-  isReady(
-    argument: _google_protobuf_Empty,
-    callback: grpc.requestCallback<_sourcetransformer_v1_ReadyResponse__Output>,
-  ): grpc.ClientUnaryCall;
-
-  SourceTransformFn(
-    metadata: grpc.Metadata,
-    options?: grpc.CallOptions,
-  ): grpc.ClientDuplexStream<
-    _sourcetransformer_v1_SourceTransformRequest,
-    _sourcetransformer_v1_SourceTransformResponse__Output
-  >;
-  SourceTransformFn(
-    options?: grpc.CallOptions,
-  ): grpc.ClientDuplexStream<
-    _sourcetransformer_v1_SourceTransformRequest,
-    _sourcetransformer_v1_SourceTransformResponse__Output
-  >;
-  sourceTransformFn(
-    metadata: grpc.Metadata,
-    options?: grpc.CallOptions,
-  ): grpc.ClientDuplexStream<
-    _sourcetransformer_v1_SourceTransformRequest,
-    _sourcetransformer_v1_SourceTransformResponse__Output
-  >;
-  sourceTransformFn(
-    options?: grpc.CallOptions,
-  ): grpc.ClientDuplexStream<
-    _sourcetransformer_v1_SourceTransformRequest,
-    _sourcetransformer_v1_SourceTransformResponse__Output
-  >;
+  /**
+   * IsReady is the heartbeat endpoint for gRPC.
+   */
+  IsReady(argument: _google_protobuf_Empty, metadata: grpc.Metadata, options: grpc.CallOptions, callback: grpc.requestCallback<_sourcetransformer_v1_ReadyResponse__Output>): grpc.ClientUnaryCall;
+  IsReady(argument: _google_protobuf_Empty, metadata: grpc.Metadata, callback: grpc.requestCallback<_sourcetransformer_v1_ReadyResponse__Output>): grpc.ClientUnaryCall;
+  IsReady(argument: _google_protobuf_Empty, options: grpc.CallOptions, callback: grpc.requestCallback<_sourcetransformer_v1_ReadyResponse__Output>): grpc.ClientUnaryCall;
+  IsReady(argument: _google_protobuf_Empty, callback: grpc.requestCallback<_sourcetransformer_v1_ReadyResponse__Output>): grpc.ClientUnaryCall;
+  /**
+   * IsReady is the heartbeat endpoint for gRPC.
+   */
+  isReady(argument: _google_protobuf_Empty, metadata: grpc.Metadata, options: grpc.CallOptions, callback: grpc.requestCallback<_sourcetransformer_v1_ReadyResponse__Output>): grpc.ClientUnaryCall;
+  isReady(argument: _google_protobuf_Empty, metadata: grpc.Metadata, callback: grpc.requestCallback<_sourcetransformer_v1_ReadyResponse__Output>): grpc.ClientUnaryCall;
+  isReady(argument: _google_protobuf_Empty, options: grpc.CallOptions, callback: grpc.requestCallback<_sourcetransformer_v1_ReadyResponse__Output>): grpc.ClientUnaryCall;
+  isReady(argument: _google_protobuf_Empty, callback: grpc.requestCallback<_sourcetransformer_v1_ReadyResponse__Output>): grpc.ClientUnaryCall;
+  
+  /**
+   * SourceTransformFn applies a function to each request element.
+   * In addition to map function, SourceTransformFn also supports assigning a new event time to response.
+   * SourceTransformFn can be used only at source vertex by source data transformer.
+   */
+  SourceTransformFn(metadata: grpc.Metadata, options?: grpc.CallOptions): grpc.ClientDuplexStream<_sourcetransformer_v1_SourceTransformRequest, _sourcetransformer_v1_SourceTransformResponse__Output>;
+  SourceTransformFn(options?: grpc.CallOptions): grpc.ClientDuplexStream<_sourcetransformer_v1_SourceTransformRequest, _sourcetransformer_v1_SourceTransformResponse__Output>;
+  /**
+   * SourceTransformFn applies a function to each request element.
+   * In addition to map function, SourceTransformFn also supports assigning a new event time to response.
+   * SourceTransformFn can be used only at source vertex by source data transformer.
+   */
+  sourceTransformFn(metadata: grpc.Metadata, options?: grpc.CallOptions): grpc.ClientDuplexStream<_sourcetransformer_v1_SourceTransformRequest, _sourcetransformer_v1_SourceTransformResponse__Output>;
+  sourceTransformFn(options?: grpc.CallOptions): grpc.ClientDuplexStream<_sourcetransformer_v1_SourceTransformRequest, _sourcetransformer_v1_SourceTransformResponse__Output>;
+  
 }
 
 export interface SourceTransformHandlers extends grpc.UntypedServiceImplementation {
+  /**
+   * IsReady is the heartbeat endpoint for gRPC.
+   */
   IsReady: grpc.handleUnaryCall<_google_protobuf_Empty__Output, _sourcetransformer_v1_ReadyResponse>;
-
-  SourceTransformFn: grpc.handleBidiStreamingCall<
-    _sourcetransformer_v1_SourceTransformRequest__Output,
-    _sourcetransformer_v1_SourceTransformResponse
-  >;
+  
+  /**
+   * SourceTransformFn applies a function to each request element.
+   * In addition to map function, SourceTransformFn also supports assigning a new event time to response.
+   * SourceTransformFn can be used only at source vertex by source data transformer.
+   */
+  SourceTransformFn: grpc.handleBidiStreamingCall<_sourcetransformer_v1_SourceTransformRequest__Output, _sourcetransformer_v1_SourceTransformResponse>;
+  
 }
 
 export interface SourceTransformDefinition extends grpc.ServiceDefinition {
-  IsReady: MethodDefinition<
-    _google_protobuf_Empty,
-    _sourcetransformer_v1_ReadyResponse,
-    _google_protobuf_Empty__Output,
-    _sourcetransformer_v1_ReadyResponse__Output
-  >;
-  SourceTransformFn: MethodDefinition<
-    _sourcetransformer_v1_SourceTransformRequest,
-    _sourcetransformer_v1_SourceTransformResponse,
-    _sourcetransformer_v1_SourceTransformRequest__Output,
-    _sourcetransformer_v1_SourceTransformResponse__Output
-  >;
+  IsReady: MethodDefinition<_google_protobuf_Empty, _sourcetransformer_v1_ReadyResponse, _google_protobuf_Empty__Output, _sourcetransformer_v1_ReadyResponse__Output>
+  SourceTransformFn: MethodDefinition<_sourcetransformer_v1_SourceTransformRequest, _sourcetransformer_v1_SourceTransformResponse, _sourcetransformer_v1_SourceTransformRequest__Output, _sourcetransformer_v1_SourceTransformResponse__Output>
 }

--- a/src/sourcetransformer/proto/sourcetransformer/v1/SourceTransformRequest.ts
+++ b/src/sourcetransformer/proto/sourcetransformer/v1/SourceTransformRequest.ts
@@ -1,40 +1,46 @@
 // Original file: proto/sourcetransformer.proto
 
-import type {
-  Handshake as _sourcetransformer_v1_Handshake,
-  Handshake__Output as _sourcetransformer_v1_Handshake__Output,
-} from '../../sourcetransformer/v1/Handshake.ts';
-import type {
-  Timestamp as _google_protobuf_Timestamp,
-  Timestamp__Output as _google_protobuf_Timestamp__Output,
-} from '../../google/protobuf/Timestamp.ts';
+import type { Handshake as _sourcetransformer_v1_Handshake, Handshake__Output as _sourcetransformer_v1_Handshake__Output } from '../../sourcetransformer/v1/Handshake.ts';
+import type { Timestamp as _google_protobuf_Timestamp, Timestamp__Output as _google_protobuf_Timestamp__Output } from '../../google/protobuf/Timestamp.ts';
 
 export interface _sourcetransformer_v1_SourceTransformRequest_Request {
-  keys?: string[];
-  value?: Buffer | Uint8Array | string;
-  eventTime?: _google_protobuf_Timestamp | null;
-  watermark?: _google_protobuf_Timestamp | null;
-  headers?: { [key: string]: string };
-  id?: string;
+  'keys'?: (string)[];
+  'value'?: (Buffer | Uint8Array | string);
+  'eventTime'?: (_google_protobuf_Timestamp | null);
+  'watermark'?: (_google_protobuf_Timestamp | null);
+  'headers'?: ({[key: string]: string});
+  /**
+   * This ID is used to uniquely identify a transform request
+   */
+  'id'?: (string);
 }
 
 export interface _sourcetransformer_v1_SourceTransformRequest_Request__Output {
-  keys: string[];
-  value: Buffer;
-  eventTime: _google_protobuf_Timestamp__Output | null;
-  watermark: _google_protobuf_Timestamp__Output | null;
-  headers: { [key: string]: string };
-  id: string;
+  'keys': (string)[];
+  'value': (Buffer);
+  'eventTime': (_google_protobuf_Timestamp__Output | null);
+  'watermark': (_google_protobuf_Timestamp__Output | null);
+  'headers': ({[key: string]: string});
+  /**
+   * This ID is used to uniquely identify a transform request
+   */
+  'id': (string);
 }
 
+/**
+ * SourceTransformerRequest represents a request element.
+ */
 export interface SourceTransformRequest {
-  request?: _sourcetransformer_v1_SourceTransformRequest_Request | null;
-  handshake?: _sourcetransformer_v1_Handshake | null;
-  _handshake?: 'handshake';
+  'request'?: (_sourcetransformer_v1_SourceTransformRequest_Request | null);
+  'handshake'?: (_sourcetransformer_v1_Handshake | null);
+  '_handshake'?: "handshake";
 }
 
+/**
+ * SourceTransformerRequest represents a request element.
+ */
 export interface SourceTransformRequest__Output {
-  request: _sourcetransformer_v1_SourceTransformRequest_Request__Output | null;
-  handshake?: _sourcetransformer_v1_Handshake__Output | null;
-  _handshake?: 'handshake';
+  'request': (_sourcetransformer_v1_SourceTransformRequest_Request__Output | null);
+  'handshake'?: (_sourcetransformer_v1_Handshake__Output | null);
+  '_handshake'?: "handshake";
 }

--- a/src/sourcetransformer/proto/sourcetransformer/v1/SourceTransformResponse.ts
+++ b/src/sourcetransformer/proto/sourcetransformer/v1/SourceTransformResponse.ts
@@ -1,38 +1,50 @@
 // Original file: proto/sourcetransformer.proto
 
-import type {
-  Handshake as _sourcetransformer_v1_Handshake,
-  Handshake__Output as _sourcetransformer_v1_Handshake__Output,
-} from '../../sourcetransformer/v1/Handshake.ts';
-import type {
-  Timestamp as _google_protobuf_Timestamp,
-  Timestamp__Output as _google_protobuf_Timestamp__Output,
-} from '../../google/protobuf/Timestamp.ts';
+import type { Handshake as _sourcetransformer_v1_Handshake, Handshake__Output as _sourcetransformer_v1_Handshake__Output } from '../../sourcetransformer/v1/Handshake.ts';
+import type { Timestamp as _google_protobuf_Timestamp, Timestamp__Output as _google_protobuf_Timestamp__Output } from '../../google/protobuf/Timestamp.ts';
 
 export interface _sourcetransformer_v1_SourceTransformResponse_Result {
-  keys?: string[];
-  value?: Buffer | Uint8Array | string;
-  eventTime?: _google_protobuf_Timestamp | null;
-  tags?: string[];
+  'keys'?: (string)[];
+  'value'?: (Buffer | Uint8Array | string);
+  'eventTime'?: (_google_protobuf_Timestamp | null);
+  'tags'?: (string)[];
 }
 
 export interface _sourcetransformer_v1_SourceTransformResponse_Result__Output {
-  keys: string[];
-  value: Buffer;
-  eventTime: _google_protobuf_Timestamp__Output | null;
-  tags: string[];
+  'keys': (string)[];
+  'value': (Buffer);
+  'eventTime': (_google_protobuf_Timestamp__Output | null);
+  'tags': (string)[];
 }
 
+/**
+ * SourceTransformerResponse represents a response element.
+ */
 export interface SourceTransformResponse {
-  results?: _sourcetransformer_v1_SourceTransformResponse_Result[];
-  id?: string;
-  handshake?: _sourcetransformer_v1_Handshake | null;
-  _handshake?: 'handshake';
+  'results'?: (_sourcetransformer_v1_SourceTransformResponse_Result)[];
+  /**
+   * This ID is used to refer the responses to the request it corresponds to.
+   */
+  'id'?: (string);
+  /**
+   * Handshake message between client and server to indicate the start of transmission.
+   */
+  'handshake'?: (_sourcetransformer_v1_Handshake | null);
+  '_handshake'?: "handshake";
 }
 
+/**
+ * SourceTransformerResponse represents a response element.
+ */
 export interface SourceTransformResponse__Output {
-  results: _sourcetransformer_v1_SourceTransformResponse_Result__Output[];
-  id: string;
-  handshake?: _sourcetransformer_v1_Handshake__Output | null;
-  _handshake?: 'handshake';
+  'results': (_sourcetransformer_v1_SourceTransformResponse_Result__Output)[];
+  /**
+   * This ID is used to refer the responses to the request it corresponds to.
+   */
+  'id': (string);
+  /**
+   * Handshake message between client and server to indicate the start of transmission.
+   */
+  'handshake'?: (_sourcetransformer_v1_Handshake__Output | null);
+  '_handshake'?: "handshake";
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,11 @@
     "moduleResolution": "node16",
     "outDir": "./dist",
     "rootDir": "./src",
-    "lib": ["es2024", "dom", "dom.iterable"],
+    "lib": [
+      "es2024",
+      "dom",
+      "dom.iterable"
+    ],
     "noEmitOnError": true,
     "esModuleInterop": true,
     "allowJs": true,
@@ -16,6 +20,13 @@
     "declaration": true,
     "declarationMap": true
   },
-  "include": ["src/**/*"],
-  "exclude": ["src/map/proto/**/*", "src/sink/proto/**/*", "src/source/proto/**/*", "src/sourcetransformer/proto/**/*"]
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "src/map/proto/**/*",
+    "src/sink/proto/**/*",
+    "src/source/proto/**/*",
+    "src/sourcetransformer/proto/**/*"
+  ]
 }


### PR DESCRIPTION
- Include comments in the generated code from protobuf definitions
- Use 4 spaces instead of 2 spaces for Typescript/Javascript indentations

2 spaces indentation feels difficult to read. Industry standard is 2 spaces, but there are exceptions like [vscode](https://github.com/microsoft/vscode/blob/9bab59302eefafc143aca3c630c4554f4c035614/tsfmt.json#L3)  that uses 4 spaces. The `aws-cdk` used to have 4 spaces https://github.com/aws/aws-cdk/issues/761.

