### PR TITLE
chore: added `prettierignore` and `husky` for pre-commit hooks

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,5 @@
+# Run Prettier to format files
+npm run format
+
+# Run tests
+npm test

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,8 @@
+# Ignore all Markdown files
+*.md
+
+# Ignore all json files
+*.json
+
+# Ignore the proto folders
+proto/

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,7 +1,8 @@
 {
-  "semi": true,
-  "trailingComma": "all",
-  "singleQuote": true,
-  "printWidth": 120,
-  "tabWidth": 4
+    "semi": true,
+    "trailingComma": "all",
+    "singleQuote": true,
+    "printWidth": 120,
+    "tabWidth": 4,
+    "proseWrap": "preserve"
 }

--- a/examples/source/fixed-data-generator/index.js
+++ b/examples/source/fixed-data-generator/index.js
@@ -4,38 +4,38 @@ const source = numa.source;
 const sleep = (duration_ms) => new Promise((resolve) => setTimeout(resolve, duration_ms));
 
 const fixedDataGenerator = {
-  offsetMap: new Map(), // Map to track offsets
+    offsetMap: new Map(), // Map to track offsets
 
-  async read(readRequest) {
-    await sleep(readRequest.timeout_ms);
-    const num = Math.floor(Math.random() * 1000);
-    const offset = source.createOffsetWithDefaultPartitionId(num.toString(10));
-    this.offsetMap.set(offset.partitionId, offset); // Track the offset
-    return [
-      {
-        value: Buffer.from('test data'),
-        offset: offset,
-        eventTime: new Date(Date.now()),
-      },
-    ];
-  },
+    async read(readRequest) {
+        await sleep(readRequest.timeout_ms);
+        const num = Math.floor(Math.random() * 1000);
+        const offset = source.createOffsetWithDefaultPartitionId(num.toString(10));
+        this.offsetMap.set(offset.partitionId, offset); // Track the offset
+        return [
+            {
+                value: Buffer.from('test data'),
+                offset: offset,
+                eventTime: new Date(Date.now()),
+            },
+        ];
+    },
 
-  async ack(offsets) {
-    offsets.forEach((offset) => {
-      if (this.offsetMap.delete(offset.partitionId)) {
-        return;
-      }
-      console.error(`Offset not found in map: ${JSON.stringify(offset)}`);
-    });
-  },
+    async ack(offsets) {
+        offsets.forEach((offset) => {
+            if (this.offsetMap.delete(offset.partitionId)) {
+                return;
+            }
+            console.error(`Offset not found in map: ${JSON.stringify(offset)}`);
+        });
+    },
 
-  async pending() {
-    return this.offsetMap.size; // Return the number of pending offsets
-  },
+    async pending() {
+        return this.offsetMap.size; // Return the number of pending offsets
+    },
 
-  async partitions() {
-    return [0];
-  },
+    async partitions() {
+        return [0];
+    },
 };
 
 source.createServer(fixedDataGenerator).start();

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
       "devDependencies": {
         "@types/node": "22.14.1",
         "@vitest/coverage-v8": "3.1.2",
+        "husky": "9.1.7",
         "prettier": "3.5.3",
         "typescript": "5.8.3",
         "vitest": "3.1.2"
@@ -1580,6 +1581,22 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/husky": {
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "husky": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
+      }
     },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "test": "vitest --run --reporter verbose",
-    "build": "rm -rf dist && npm run format && tsc"
+    "build": "rm -rf dist && npm run format && tsc",
+    "prepare": "husky"
   },
   "keywords": [],
   "author": "",
@@ -30,6 +31,7 @@
   "devDependencies": {
     "@types/node": "22.14.1",
     "@vitest/coverage-v8": "3.1.2",
+    "husky": "9.1.7",
     "prettier": "3.5.3",
     "typescript": "5.8.3",
     "vitest": "3.1.2"


### PR DESCRIPTION
1. `prettierignore` - ignore markdown, .json files and proto folders while formatting
2. `husky` - `npm run format` and `npm run test` as pre-commit hooks