### PR TITLE
chore: nit fixes for consistency across SDK components

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,10 +14,11 @@ This document provides guidelines and instructions for contributing to the proje
 
 ## Overview
 
-Numaflow-JS is a JavaScript/TypeScript SDK for  [Numaflow](https://numaflow.numaproj.io/)  that leverages Rust FFI through [NAPI-RS](https://napi.rs/) to 
+Numaflow-JS is a JavaScript/TypeScript SDK for [Numaflow](https://numaflow.numaproj.io/) that leverages Rust FFI through [NAPI-RS](https://napi.rs/) to
 provide bindings for the [Numaflow Rust SDK](https://github.com/numaproj/numaflow-rs).
 
 The codebase consists of following layers:
+
 <!-- Added an HTML table below to allow merging cells across columns -->
 <table style="text-align: center; vertical-align: middle;">
   <tr>
@@ -53,27 +54,26 @@ The codebase consists of following layers:
   </tr>
 </table>
 
-
 ## Prerequisites
 
 Before you begin, ensure you have the following installed:
 
 ### Required Tools
 
-| Tool | Version               | Installation |
-|------|-----------------------|--------------|
-| **Node.js** | \>= 20                | [nodejs.org](https://nodejs.org/) or use `nvm` |
-| **pnpm** | 10.24.0+              | `npm install -g pnpm` or [pnpm.io](https://pnpm.io/installation) |
-| **Rust** | stable (2024 edition) | [rustup.rs](https://rustup.rs/) |
-| **Cargo** | (comes with Rust)     | Included with Rust installation |
+| Tool        | Version               | Installation                                                     |
+| ----------- | --------------------- | ---------------------------------------------------------------- |
+| **Node.js** | \>= 20                | [nodejs.org](https://nodejs.org/) or use `nvm`                   |
+| **pnpm**    | 10.24.0+              | `npm install -g pnpm` or [pnpm.io](https://pnpm.io/installation) |
+| **Rust**    | stable (2024 edition) | [rustup.rs](https://rustup.rs/)                                  |
+| **Cargo**   | (comes with Rust)     | Included with Rust installation                                  |
 
 ### Verify Installation
 
 ```shell
-node --version 
-pnpm --version    
-rustc --version 
-cargo --version 
+node --version
+pnpm --version
+rustc --version
+cargo --version
 ```
 
 ## Development Setup
@@ -94,11 +94,13 @@ pnpm install
 3. **Build the project**
 
 Debug build (faster compilation, includes debug symbols)
+
 ```shell
 pnpm build:debug
 ```
 
 OR Release build (optimized, slower to compile)
+
 ```shell
 pnpm build
 ```
@@ -116,24 +118,31 @@ The build process has two stages:
 ### 1. Build Rust to Native Binary
 
 Debug build (development)
+
 ```shell
 pnpm build:rs
 ```
 
 Release build (production)
+
 ```shell
 pnpm build:rs --release
 ```
+
 This compiles the Rust code in `src/` and generates:
+
 - `numaflow-js.*.node` - Platform-specific native binary
 - `binding.js` - JavaScript loader with platform detection
 - `binding.d.ts` - TypeScript definitions for the Rust bindings
 
 ### 2. Build TypeScript Wrapper
+
 ```shell
 pnpm build:ts
 ```
+
 This compiles `index.ts` to generate:
+
 - `index.js` - JavaScript wrapper with additional conveniences
 - `index.d.ts` - TypeScript definitions for the wrapper
 
@@ -143,11 +152,13 @@ Instead of the above two separate steps, we can use the following commands to bu
 This also includes formatting and linting steps.
 
 Debug (recommended for development)
+
 ```shell
 pnpm build:debug
 ```
 
 Release (for production/publishing)
+
 ```shell
 pnpm build
 ```
@@ -163,11 +174,13 @@ pnpm test
 ```
 
 Run a specific test file
+
 ```shell
 pnpm vitest run tests/__test__/sink-integration.spec.ts
 ```
 
 Run a subset of tests
+
 ```shell
 pnpm vitest run -t "source"
 ```
@@ -176,6 +189,7 @@ pnpm vitest run -t "source"
 
 The test suite currently only includes integration tests.
 Each test under `tests/__test__/` does the following:
+
 1. Starts the JS test async server for the respective component defined in `<test-name>.spec.ts`.
 2. Runs the respective Rust test binary from `tests/src/`
 3. The Rust test binary creates a client and calls the JS test async server.
@@ -212,7 +226,9 @@ numaflow-js/
 ```
 
 ## Adding a New Feature
+
 When adding a new Numaflow component or feature:
+
 1. Implement in Rust
 2. Build to generate bindings using napi.rs
 3. Update/Create TypeScript wrapper if required

--- a/README.md
+++ b/README.md
@@ -45,12 +45,14 @@ Most of the examples follow a similar structure:
 In the implementation part of all the examples presented, i.e. in `<example-name>.ts`, the pattern is mostly similar.
 We need to instantiate and start an async server for the respective component being implemented.
 
+## Implementation details with examples
+
 Eg: Implementing UD sink component:
 
-- To implement a UD sink need to use `sink.SinkAsyncServer`.
-- To instantiate the server, we need to provide a function `sinkFn` with a signature satisfying `SinkAsyncServer` constructor.
-- Start the server using `start` method of `SinkAsyncServer`.
-- Stop the server using `stop` method of `SinkAsyncServer`.
+- To implement a UD sink need to use `sink.AsyncServer`.
+- To instantiate the server, we need to provide a function `sinkFn` with a signature satisfying `AsyncServer` constructor.
+- Start the server using `start` method of `AsyncServer`.
+- Stop the server using `stop` method of `AsyncServer`.
 
 Currently, `source` and `session-reduce` components require implementing all methods of an interface and passing an instance
 of the same to their respective async server constructors. Rest of the components only require implementing a function with a signature
@@ -66,7 +68,7 @@ const sinkFn = (message: Message) => {
     console.log(message)
 }
 
-const server = new sink.SinkAsyncServer(sinkFn)
+const server = new sink.AsyncServer(sinkFn)
 ```
 
 Still works if defined as part of a class.
@@ -81,7 +83,7 @@ class Sink {
 }
 
 let sinker = new Sink()
-const server = new sink.SinkAsyncServer(sinker.sinkFn)
+const server = new sink.AsyncServer(sinker.sinkFn)
 ```
 
 2. Using a named function <br>
@@ -93,7 +95,7 @@ function sinkFn(message: Message) {
     console.log(message)
 }
 
-const server = new sink.SinkAsyncServer(sinkFn)
+const server = new sink.AsyncServer(sinkFn)
 ```
 
 Named functions defined as part of a class may need to be bound to the instance of the class.
@@ -108,7 +110,7 @@ class Sink {
 }
 
 let sinker = new Sink()
-const server = new sink.SinkAsyncServer(sinker.sinkFn.bind(sinker))
+const server = new sink.AsyncServer(sinker.sinkFn.bind(sinker))
 ```
 
 If any of the examples are failing to build or if they need further clarification, please create an [issue](https://github.com/numaproj/numaflow-js/issues/new/choose) to fix the same.

--- a/README.md
+++ b/README.md
@@ -5,13 +5,13 @@ Numaflow-JS is an SDK for [Numaflow](https://numaflow.numaproj.io/) that provide
 Currently, these include:
 
 - [Map UDF](https://numaflow.numaproj.io/user-guide/user-defined-functions/map/map/)
-  - [Streaming mode](https://numaflow.numaproj.io/user-guide/user-defined-functions/map/map/#streaming-mode)
-  - [BatchMap mode](https://numaflow.numaproj.io/user-guide/user-defined-functions/map/map/#batch-map-mode)
+    - [Streaming mode](https://numaflow.numaproj.io/user-guide/user-defined-functions/map/map/#streaming-mode)
+    - [BatchMap mode](https://numaflow.numaproj.io/user-guide/user-defined-functions/map/map/#batch-map-mode)
 - [Reduce UDF](https://numaflow.numaproj.io/user-guide/user-defined-functions/reduce/reduce/)
-  - [Accumulator](https://numaflow.numaproj.io/user-guide/user-defined-functions/reduce/windowing/accumulator/)
-  - [Session](https://numaflow.numaproj.io/user-guide/user-defined-functions/reduce/windowing/session/)
-  - [Fixed](https://numaflow.numaproj.io/user-guide/user-defined-functions/reduce/windowing/fixed/)
-  - [Sliding](https://numaflow.numaproj.io/user-guide/user-defined-functions/reduce/windowing/sliding/)
+    - [Accumulator](https://numaflow.numaproj.io/user-guide/user-defined-functions/reduce/windowing/accumulator/)
+    - [Session](https://numaflow.numaproj.io/user-guide/user-defined-functions/reduce/windowing/session/)
+    - [Fixed](https://numaflow.numaproj.io/user-guide/user-defined-functions/reduce/windowing/fixed/)
+    - [Sliding](https://numaflow.numaproj.io/user-guide/user-defined-functions/reduce/windowing/sliding/)
 - [UD Sink](https://numaflow.numaproj.io/user-guide/sinks/user-defined-sinks/)
 - [UD Source](https://numaflow.numaproj.io/user-guide/sources/user-defined-sources/)
 - [Source Transform](https://numaflow.numaproj.io/user-guide/sources/transformer/overview/)
@@ -35,6 +35,7 @@ Numaflow-JS.
 Each example focuses implementing and building one specific component of Numaflow.
 
 Most of the examples follow a similar structure:
+
 - `Dockerfile`: Contains the instructions to build the Docker image for the example.
 - `Makefile`: Contains helper commands to build the Docker image
 - `README.md`: Provides details on implementing the concerned type of component and instructions to run the specific example.
@@ -45,6 +46,7 @@ In the implementation part of all the examples presented, i.e. in `<example-name
 We need to instantiate and start an async server for the respective component being implemented.
 
 Eg: Implementing UD sink component:
+
 - To implement a UD sink need to use `sink.SinkAsyncServer`.
 - To instantiate the server, we need to provide a function `sinkFn` with a signature satisfying `SinkAsyncServer` constructor.
 - Start the server using `start` method of `SinkAsyncServer`.
@@ -57,52 +59,56 @@ satisfying the constructor of the async server.
 Following are the different ways to implement a function with a signature satisfying the constructor of the async server:
 
 1. Using an arrow function <br>
-If the function is small and simple, we can use an arrow function.
+   If the function is small and simple, we can use an arrow function.
+
 ```typescript
 const sinkFn = (message: Message) => {
-    console.log(message);
-};
+    console.log(message)
+}
 
-const server = new sink.SinkAsyncServer(sinkFn);
+const server = new sink.SinkAsyncServer(sinkFn)
 ```
 
 Still works if defined as part of a class.
+
 ```typescript
 class Sink {
-    counter = 0;
+    counter = 0
     sinkFn = (message: Message) => {
-        this.counter++;
-        console.log(this.counter, message);
+        this.counter++
+        console.log(this.counter, message)
     }
 }
 
 let sinker = new Sink()
-const server = new sink.SinkAsyncServer(sinker.sinkFn);
+const server = new sink.SinkAsyncServer(sinker.sinkFn)
 ```
 
 2. Using a named function <br>
 
 Simple named functions work the same way.
+
 ```typescript
 function sinkFn(message: Message) {
-    console.log(message);
+    console.log(message)
 }
 
-const server = new sink.SinkAsyncServer(sinkFn);
+const server = new sink.SinkAsyncServer(sinkFn)
 ```
 
 Named functions defined as part of a class may need to be bound to the instance of the class.
+
 ```typescript
 class Sink {
-    counter = 0;
+    counter = 0
     sinkFn(message: Message) {
-        this.counter++;
-        console.log(this.counter, message);
+        this.counter++
+        console.log(this.counter, message)
     }
 }
 
 let sinker = new Sink()
-const server = new sink.SinkAsyncServer(sinker.sinkFn.bind(sinker));
+const server = new sink.SinkAsyncServer(sinker.sinkFn.bind(sinker))
 ```
 
 If any of the examples are failing to build or if they need further clarification, please create an [issue](https://github.com/numaproj/numaflow-js/issues/new/choose) to fix the same.

--- a/binding.d.ts
+++ b/binding.d.ts
@@ -75,20 +75,6 @@ export declare namespace batchmap {
         start(sockFile?: string | undefined | null, infoFile?: string | undefined | null): Promise<void>
         stop(): void
     }
-    export class BatchMessage {
-        /**
-         * Keys are a collection of strings which will be passed on to the next vertex as is. It can
-         * be an empty collection.
-         */
-        keys?: Array<string>
-        /** Value is the value passed to the next vertex. */
-        value: Array<number>
-        /** Tags are used for [conditional forwarding](https://numaflow.numaproj.io/user-guide/reference/conditional-forwarding/). */
-        tags?: Array<string>
-        constructor(value: Buffer)
-        withKeys(keys: Array<string>): BatchMessage
-        withTags(tags: Array<string>): BatchMessage
-    }
     export class BatchResponse {
         constructor(id: string)
         static fromId(id: string): BatchResponse
@@ -120,6 +106,17 @@ export declare namespace batchmap {
     export interface BatchDatumIteratorResult {
         value?: BatchDatum
         done: boolean
+    }
+    export interface BatchMessage {
+        /**
+         * Keys are a collection of strings which will be passed on to the next vertex as is. It can
+         * be an empty collection.
+         */
+        keys?: Array<string>
+        /** Value is the value passed to the next vertex. */
+        value: Buffer
+        /** Tags are used for [conditional forwarding](https://numaflow.numaproj.io/user-guide/reference/conditional-forwarding/). */
+        tags?: Array<string>
     }
     export function messageToDrop(): BatchMessage
 }

--- a/binding.d.ts
+++ b/binding.d.ts
@@ -18,7 +18,7 @@ export declare namespace accumulator {
     }
     export interface Datum {
         keys: Array<string>
-        value: Array<number>
+        value: Buffer
         watermark: Date
         eventTime: Date
         headers: Record<string, string>
@@ -31,7 +31,7 @@ export declare namespace accumulator {
     /** Create a Message from a Datum, preserving all metadata. */
     export function fromDatum(
         datum: Datum,
-        value?: Array<number> | undefined | null,
+        value?: Buffer | undefined | null,
         keys?: Array<string> | undefined | null,
         tags?: Array<string> | undefined | null,
     ): Message
@@ -43,7 +43,7 @@ export declare namespace accumulator {
          */
         keys?: Array<string>
         /** Value is the value passed to the next vertex. */
-        value: Array<number>
+        value: Buffer
         /** Tags are used for [conditional forwarding](https://numaflow.numaproj.io/user-guide/reference/conditional-forwarding/). */
         tags?: Array<string>
         /** ID is used for deduplication. Read-only, set from the input datum. */
@@ -130,7 +130,7 @@ export declare namespace map {
         keys: Array<string>
         constructor(
             keys: Array<string>,
-            value: Array<number>,
+            value: Buffer,
             watermark: Date,
             eventTime: Date,
             headers: Record<string, string>,
@@ -311,7 +311,7 @@ export declare namespace sessionReduce {
     }
     export interface Datum {
         keys: Array<string>
-        value: Array<number>
+        value: Buffer
         watermark: Date
         eventTime: Date
         headers: Record<string, string>
@@ -386,7 +386,7 @@ export declare namespace sink {
         static failure(id: string, err: string): SinkResponse
         static ok(id: string): SinkResponse
         static fallback(id: string): SinkResponse
-        static serve(id: string, payload: Array<number>): SinkResponse
+        static serve(id: string, payload: Buffer): SinkResponse
         static onSuccess(id: string, payload?: SinkMessage | undefined | null): SinkResponse
     }
     export class SinkResponses {

--- a/binding.d.ts
+++ b/binding.d.ts
@@ -111,7 +111,7 @@ export declare namespace batchmap {
          */
         watermark: Date
         /** Time of the element as seen at source or aligned after a reduce operation. */
-        eventtime: Date
+        eventTime: Date
         /** ID is the unique id of the message */
         id: string
         /** Headers for the message. */
@@ -132,14 +132,14 @@ export declare namespace map {
             keys: Array<string>,
             value: Array<number>,
             watermark: Date,
-            eventtime: Date,
+            eventTime: Date,
             headers: Record<string, string>,
             userMetadata?: UserMetadata | undefined | null,
             systemMetadata?: SystemMetadata | undefined | null,
         )
         get value(): Buffer
         get watermark(): Date
-        get eventtime(): Date
+        get eventTime(): Date
         get headers(): Record<string, string>
         get userMetadata(): UserMetadata | null
         get systemMetadata(): SystemMetadata | null
@@ -198,7 +198,7 @@ export declare namespace mapstream {
          */
         watermark: Date
         /** Time of the element as seen at source or aligned after a reduce operation. */
-        eventtime: Date
+        eventTime: Date
         /** Headers associated with the message. */
         headers: Record<string, string>
     }
@@ -313,7 +313,7 @@ export declare namespace sessionReduce {
         keys: Array<string>
         value: Array<number>
         watermark: Date
-        eventtime: Date
+        eventTime: Date
         headers: Record<string, string>
     }
     export interface Message {
@@ -475,14 +475,14 @@ export declare namespace sourceTransform {
             keys: Array<string>,
             value: Buffer,
             watermark: Date,
-            eventtime: Date,
+            eventTime: Date,
             headers: Record<string, string>,
             userMetadata?: SourceTransformUserMetadata | undefined | null,
             systemMetadata?: SourceTransformSystemMetadata | undefined | null,
         )
         get value(): Buffer
         get watermark(): Date
-        get eventtime(): Date
+        get eventTime(): Date
         get headers(): Record<string, string>
         get userMetadata(): SourceTransformUserMetadata | null
         get systemMetadata(): SourceTransformSystemMetadata | null
@@ -504,7 +504,7 @@ export declare namespace sourceTransform {
         removeKey(group: string, key: string): void
         removeGroup(group: string): void
     }
-    export function messageToDrop(eventtime: Date): SourceTransformMessage
+    export function messageToDrop(eventTime: Date): SourceTransformMessage
     export interface SourceTransformMessage {
         /**
          * Keys are a collection of strings which will be passed on to the next vertex as is. It can
@@ -517,7 +517,7 @@ export declare namespace sourceTransform {
          * Time for the given event. This will be used for tracking watermarks. If cannot be derived, set it to the incoming
          * event_time from the [`SourceTransformRequest`].
          */
-        eventtime: Date
+        eventTime: Date
         /** Tags are used for [conditional forwarding](https://numaflow.numaproj.io/user-guide/reference/conditional-forwarding/). */
         tags?: Array<string>
         /** User metadata for the message. */

--- a/examples/accumulator/stream-sorter.ts
+++ b/examples/accumulator/stream-sorter.ts
@@ -3,7 +3,7 @@ import { accumulator } from '../../index'
 class StreamSorter {
     latest_wm: Date = new Date(-1)
     sorted_buffer: accumulator.Datum[] = []
-    async *streamSorter(datums: accumulator.DatumIterator): AsyncIterable<accumulator.Message> {
+    async *streamSorter(datums: AsyncIterableIterator<accumulator.Datum>): AsyncIterable<accumulator.Message> {
         let datum_count = 0
         for await (let datum of datums) {
             datum_count += 1

--- a/examples/accumulator/stream-sorter.ts
+++ b/examples/accumulator/stream-sorter.ts
@@ -96,7 +96,7 @@ class StreamSorter {
 async function main() {
     const streamSorter = new StreamSorter()
     // bind streamSorter to streamSorter.streamSorter
-    const server = new accumulator.AccumulatorAsyncServer(streamSorter.streamSorter.bind(streamSorter))
+    const server = new accumulator.AsyncServer(streamSorter.streamSorter.bind(streamSorter))
 
     const shutdown = () => {
         server.stop()

--- a/examples/batchmap/batch-map.ts
+++ b/examples/batchmap/batch-map.ts
@@ -1,6 +1,6 @@
 import { batchmap } from '../../index'
 
-async function batchMapFn(datums: batchmap.DatumIterator): Promise<batchmap.Response[]> {
+async function batchMapFn(datums: AsyncIterableIterator<batchmap.Datum>): Promise<batchmap.Response[]> {
     let responses: Array<batchmap.Response> = []
     for await (let datum of datums) {
         console.log('Datum id received ' + datum.id + ' keys ' + datum.keys + ' value ' + datum.value)

--- a/examples/batchmap/batch-map.ts
+++ b/examples/batchmap/batch-map.ts
@@ -14,7 +14,7 @@ async function batchMapFn(datums: batchmap.DatumIterator): Promise<batchmap.Resp
 }
 
 async function main() {
-    const batchMapper = new batchmap.BatchMapAsyncServer(batchMapFn)
+    const batchMapper = new batchmap.AsyncServer(batchMapFn)
 
     const shutdown = () => {
         batchMapper.stop()

--- a/examples/batchmap/batch-map.ts
+++ b/examples/batchmap/batch-map.ts
@@ -4,7 +4,10 @@ async function batchMapFn(datums: AsyncIterableIterator<batchmap.Datum>): Promis
     let responses: Array<batchmap.Response> = []
     for await (let datum of datums) {
         console.log('Datum id received ' + datum.id + ' keys ' + datum.keys + ' value ' + datum.value)
-        let message = new batchmap.Message(datum.value).withKeys(datum.keys)
+        let message = {
+            value: datum.value,
+            keys: datum.keys,
+        }
         let response = new batchmap.Response(datum.id)
         response.append(message)
         responses.push(response)

--- a/examples/mapper/mapper.ts
+++ b/examples/mapper/mapper.ts
@@ -1,5 +1,5 @@
 import { map } from '../../index.js'
-const { MapServer, Message } = map
+const { Message } = map
 
 async function mapFn(datum: map.Datum): Promise<map.Message[]> {
     console.log(`mapFn: ${JSON.stringify(datum)}`)
@@ -27,7 +27,7 @@ async function mapFn(datum: map.Datum): Promise<map.Message[]> {
 
 async function main() {
     console.log('Starting mapper')
-    const server = new MapServer(mapFn)
+    const server = new map.AsyncServer(mapFn)
 
     const shutdown = () => {
         server.stop()

--- a/examples/mapstream/mapstream.ts
+++ b/examples/mapstream/mapstream.ts
@@ -12,7 +12,7 @@ async function* streamMapFn(datum: mapstream.Datum) {
 }
 
 async function main() {
-    const server = new mapstream.MapStreamAsyncServer(streamMapFn)
+    const server = new mapstream.AsyncServer(streamMapFn)
 
     const shutdown = () => {
         server.stop()

--- a/examples/reduce/reduce.ts
+++ b/examples/reduce/reduce.ts
@@ -15,7 +15,7 @@ async function reduceFn(
 }
 
 async function main() {
-    const server = new reduce.ReduceAsyncServer(reduceFn)
+    const server = new reduce.AsyncServer(reduceFn)
 
     const shutdown = () => {
         server.stop()

--- a/examples/reducestream/reducestream.ts
+++ b/examples/reducestream/reducestream.ts
@@ -16,7 +16,7 @@ async function* reduceStreamFn(
 }
 
 async function main() {
-    const server = new reduceStream.ReduceStreamAsyncServer(reduceStreamFn)
+    const server = new reduceStream.AsyncServer(reduceStreamFn)
 
     const shutdown = () => {
         server.stop()

--- a/examples/session-reduce/session-reduce.ts
+++ b/examples/session-reduce/session-reduce.ts
@@ -27,7 +27,7 @@ class SessionReduceCounter implements sessionReduce.SessionReducer {
 }
 
 async function main() {
-    const server = new sessionReduce.SessionReduceAsyncServer(new SessionReduceCounter())
+    const server = new sessionReduce.AsyncServer(new SessionReduceCounter())
 
     const shutdown = () => {
         server.stop()

--- a/examples/sinker/sinker.ts
+++ b/examples/sinker/sinker.ts
@@ -16,7 +16,7 @@ async function sinkFn(datums: AsyncIterableIterator<sink.Datum>): Promise<sink.R
 }
 
 async function main() {
-    const sinker = new sink.SinkAsyncServer(sinkFn)
+    const sinker = new sink.AsyncServer(sinkFn)
 
     const shutdown = () => {
         console.log('Received shutdown signal')

--- a/examples/source-transform/source-transformer.ts
+++ b/examples/source-transform/source-transformer.ts
@@ -12,7 +12,7 @@ async function sourceTransformFn(datum: sourceTransform.Datum): Promise<sourceTr
 }
 
 async function main() {
-    const server = new sourceTransform.SourceTransformAsyncServer(sourceTransformFn)
+    const server = new sourceTransform.AsyncServer(sourceTransformFn)
 
     const shutdown = () => {
         server.stop()

--- a/examples/source-transform/source-transformer.ts
+++ b/examples/source-transform/source-transformer.ts
@@ -5,7 +5,7 @@ async function sourceTransformFn(datum: sourceTransform.Datum): Promise<sourceTr
         {
             keys: datum.keys,
             value: datum.value,
-            eventtime: datum.eventtime,
+            eventTime: datum.eventTime,
             tags: [],
         },
     ]

--- a/examples/source/source.ts
+++ b/examples/source/source.ts
@@ -49,7 +49,7 @@ class Sourcer implements source.Sourcer {
 }
 
 async function main() {
-    const server = new source.SourceAsyncServer(new Sourcer())
+    const server = new source.AsyncServer(new Sourcer())
 
     const shutdown = () => {
         server.stop()

--- a/index.d.ts
+++ b/index.d.ts
@@ -31,7 +31,7 @@ export declare namespace sourceTransform {
         constructor(value: Buffer, eventtime: Date, options?: MessageOptions);
         static toDrop(eventtime: Date): Message;
     }
-    export class SourceTransformAsyncServer {
+    export class AsyncServer {
         private readonly nativeServer;
         constructor(sourceTransformFn: (message: Datum) => Promise<Message[]>);
         start(socketPath?: string | null, serverInfoPath?: string | null): Promise<void>;
@@ -60,21 +60,21 @@ export declare namespace accumulator {
         [Symbol.asyncIterator](): AsyncIterableIterator<Datum>;
     }
     /**
-     * AccumulatorAsyncServer is a wrapper around a JavaScript callable that will be passed by the user to process the
+     * AsyncServer is a wrapper around a JavaScript callable that will be passed by the user to process the
      * data received by the Sink.
      */
-    class AccumulatorAsyncServer {
+    class AsyncServer {
         private readonly nativeServer;
         /**
          * Create a new Sink with the given callback.
          */
         constructor(accumulatorFn: (datum: DatumIterator) => AsyncIterable<Message>);
         /**
-         * Start the AccumulatorAsyncServer server with the given callback
+         * Start the AsyncServer server with the given callback
          */
         start(socketPath?: string | null, serverInfoPath?: string | null): Promise<void>;
         /**
-         * Stop the AccumulatorAsyncServer server
+         * Stop the AsyncServer server
          */
         stop(): void;
     }
@@ -97,7 +97,7 @@ export declare namespace map {
         constructor(value: Buffer, options?: MessageOptions);
         static toDrop(): Message;
     }
-    class MapServer {
+    class AsyncServer {
         private readonly nativeServer;
         constructor(mapFn: (message: Datum) => Promise<Message[]>);
         start(socketPath?: string | null, serverInfoPath?: string | null): Promise<void>;
@@ -119,8 +119,8 @@ export declare namespace sink {
     export type Responses = binding.sink.SinkResponses;
     export const Message: typeof binding.sink.SinkMessage;
     export type Message = binding.sink.SinkMessage;
-    export const SinkAsyncServer: typeof SinkAsyncServerImpl;
-    export type SinkAsyncServer = SinkAsyncServerImpl;
+    export const AsyncServer: typeof SinkAsyncServerImpl;
+    export type AsyncServer = SinkAsyncServerImpl;
     export {};
 }
 export declare namespace batchmap {
@@ -150,8 +150,8 @@ export declare namespace batchmap {
     export const messageToDrop: typeof binding.batchmap.messageToDrop;
     export const DatumIterator: typeof BatchDatumIteratorImpl;
     export type DatumIterator = BatchDatumIteratorImpl;
-    export const BatchMapAsyncServer: typeof BatchMapAsyncServerImpl;
-    export type BatchMapAsyncServer = BatchMapAsyncServerImpl;
+    export const AsyncServer: typeof BatchMapAsyncServerImpl;
+    export type AsyncServer = BatchMapAsyncServerImpl;
     export {};
 }
 export declare namespace mapstream {
@@ -159,7 +159,7 @@ export declare namespace mapstream {
     export type Message = binding.mapstream.Message;
     type MapStreamCallback = (datum: Datum) => AsyncIterable<Message>;
     export const messageToDrop: typeof binding.mapstream.messageToDrop;
-    export class MapStreamAsyncServer {
+    export class AsyncServer {
         private readonly mapper;
         constructor(mapFn: MapStreamCallback);
         start(sockFile?: string | null, infoFile?: string | null): Promise<void>;
@@ -180,8 +180,8 @@ export declare namespace reduce {
     export type IntervalWindow = binding.reduce.IntervalWindow;
     export type Message = binding.reduce.Message;
     export type DatumIteratorResult = binding.reduce.ReduceDatumIteratorResult;
-    export const ReduceAsyncServer: typeof ReduceAsyncServerImpl;
-    export type ReduceAsyncServer = ReduceAsyncServerImpl;
+    export const AsyncServer: typeof ReduceAsyncServerImpl;
+    export type AsyncServer = ReduceAsyncServerImpl;
     export {};
 }
 export declare namespace sessionReduce {
@@ -197,21 +197,21 @@ export declare namespace sessionReduce {
         mergeAccumulatorFn: MergeAccumulatorFnCallback;
     }
     /**
-     * SessionReduceAsyncServer is a wrapper around a JavaScript callable that will be passed by the user to process the
+     * AsyncServer is a wrapper around a JavaScript callable that will be passed by the user to process the
      * data received by the SessionReduce.
      */
-    export class SessionReduceAsyncServer {
+    export class AsyncServer {
         private readonly nativeServer;
         /**
-         * Create a new SessionReduceAsyncServer with the given callback.
+         * Create a new AsyncServer with the given callback.
          */
         constructor(sessionReducerImpl: SessionReducer);
         /**
-         * Start the SessionReduceAsyncServer server with the given callback
+         * Start the AsyncServer server with the given callback
          */
         start(socketPath?: string | null, serverInfoPath?: string | null): Promise<void>;
         /**
-         * Stop the SessionReduceAsyncServer server
+         * Stop the AsyncServer server
          */
         stop(): void;
     }
@@ -224,21 +224,21 @@ export declare namespace reduceStream {
     export const messageToDrop: typeof binding.reduce.messageToDrop;
     type CallbackFn = (keys: string[], iterator: AsyncIterableIterator<Datum>, metadata: Metadata) => AsyncIterable<Message>;
     /**
-     * SessionReduceAsyncServer is a wrapper around a JavaScript callable that will be passed by the user to process the
+     * AsyncServer is a wrapper around a JavaScript callable that will be passed by the user to process the
      * data received by the SessionReduce.
      */
-    export class ReduceStreamAsyncServer {
+    export class AsyncServer {
         private readonly nativeServer;
         /**
-         * Create a new ReduceStreamAsyncServer with the given callback.
+         * Create a new AsyncServer with the given callback.
          */
         constructor(callbackFn: CallbackFn);
         /**
-         * Start the ReduceStreamAsyncServer server with the given callback
+         * Start the AsyncServer server with the given callback
          */
         start(socketPath?: string | null, serverInfoPath?: string | null): Promise<void>;
         /**
-         * Stop the ReduceStreamAsyncServer server
+         * Stop the AsyncServer server
          */
         stop(): void;
     }
@@ -246,6 +246,7 @@ export declare namespace reduceStream {
 }
 export declare namespace source {
     type ReadRequest = binding.source.ReadRequest;
+    type NativeMessage = binding.source.Message;
     type UserMetadata = binding.source.SourceUserMetadata;
     const UserMetadata: typeof binding.source.SourceUserMetadata;
     type Offset = binding.source.Offset;
@@ -265,7 +266,7 @@ export declare namespace source {
         userMetadata?: UserMetadata;
         constructor(payload: Buffer, offset: Offset, eventTime: Date, keys: string[], headers: Record<string, string>, userMetadata?: UserMetadata);
     }
-    class SourceAsyncServer {
+    class AsyncServer {
         private readonly nativeServer;
         constructor(sourcer: Sourcer);
         start(socketPath?: string | null, serverInfoPath?: string | null): Promise<void>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -41,8 +41,23 @@ export declare namespace sourceTransform {
 }
 export declare namespace accumulator {
     type Datum = binding.accumulator.Datum;
-    type Message = binding.accumulator.Message;
+    type NativeMessage = binding.accumulator.Message;
     const messageToDrop: typeof binding.accumulator.messageToDrop;
+    interface MessageOptions {
+        keys?: string[];
+        tags?: string[];
+    }
+    class Message implements NativeMessage {
+        keys?: Array<string>;
+        value: Buffer;
+        tags?: Array<string>;
+        id: string;
+        headers: Record<string, string>;
+        eventTime: Date;
+        watermark: Date;
+        constructor(value: Buffer, id: string, eventTime: Date, watermark: Date, headers: Record<string, string>, options?: MessageOptions);
+        static toDrop(): Message;
+    }
     /**
      * AsyncServer is a wrapper around a JavaScript callable that will be passed by the user to process the
      * data received by the Sink.
@@ -128,9 +143,20 @@ export declare namespace batchmap {
 }
 export declare namespace mapstream {
     export type Datum = binding.mapstream.Datum;
-    export type Message = binding.mapstream.Message;
+    export type NativeMessage = binding.mapstream.Message;
     type MapStreamCallback = (datum: Datum) => AsyncIterable<Message>;
     export const messageToDrop: typeof binding.mapstream.messageToDrop;
+    export interface MessageOptions {
+        keys?: string[];
+        tags?: string[];
+    }
+    export class Message implements NativeMessage {
+        value: Buffer;
+        keys?: string[];
+        tags?: string[];
+        constructor(value: Buffer, options?: MessageOptions);
+        static toDrop(): Message;
+    }
     export class AsyncServer {
         private readonly mapper;
         constructor(mapFn: MapStreamCallback);
@@ -141,24 +167,47 @@ export declare namespace mapstream {
 }
 export declare namespace reduce {
     export type Datum = binding.reduce.Datum;
-    type Callback = (keys: string[], iterator: AsyncIterableIterator<Datum>, metadata: Metadata) => Promise<binding.reduce.Message[]>;
+    export type NativeMessage = binding.reduce.Message;
+    export type Metadata = binding.reduce.Metadata;
+    export type IntervalWindow = binding.reduce.IntervalWindow;
+    export const messageToDrop: typeof binding.reduce.messageToDrop;
+    export interface MessageOptions {
+        keys?: string[];
+        tags?: string[];
+    }
+    export class Message implements NativeMessage {
+        value: Buffer;
+        keys?: string[];
+        tags?: string[];
+        constructor(value: Buffer, options?: MessageOptions);
+        static toDrop(): Message;
+    }
+    type Callback = (keys: string[], iterator: AsyncIterableIterator<Datum>, metadata: Metadata) => Promise<Message[]>;
     class ReduceAsyncServerImpl {
         private readonly nativeServer;
         constructor(reduceFn: Callback);
         start(socketPath?: string | null, serverInfoPath?: string | null): Promise<void>;
         stop(): void;
     }
-    export type Metadata = binding.reduce.Metadata;
-    export type IntervalWindow = binding.reduce.IntervalWindow;
-    export type Message = binding.reduce.Message;
     export const AsyncServer: typeof ReduceAsyncServerImpl;
     export type AsyncServer = ReduceAsyncServerImpl;
     export {};
 }
 export declare namespace sessionReduce {
     export type Datum = binding.sessionReduce.Datum;
-    export type Message = binding.sessionReduce.Message;
+    export type NativeMessage = binding.sessionReduce.Message;
     export const messageToDrop: typeof binding.sessionReduce.messageToDrop;
+    export interface MessageOptions {
+        keys?: string[];
+        tags?: string[];
+    }
+    export class Message implements NativeMessage {
+        value: Buffer;
+        keys?: string[];
+        tags?: string[];
+        constructor(value: Buffer, options?: MessageOptions);
+        static toDrop(): Message;
+    }
     type SessionReduceFnCallback = (keys: string[], iterator: AsyncIterableIterator<Datum>) => AsyncIterable<Message>;
     type AccumulatorFnCallback = () => Promise<Buffer>;
     type MergeAccumulatorFnCallback = (accumulator: Buffer) => Promise<void>;
@@ -190,9 +239,20 @@ export declare namespace sessionReduce {
 }
 export declare namespace reduceStream {
     export type Datum = binding.reduce.Datum;
-    export type Message = binding.reduce.Message;
+    export type NativeMessage = binding.reduce.Message;
     export type Metadata = binding.reduce.Metadata;
     export const messageToDrop: typeof binding.reduce.messageToDrop;
+    export interface MessageOptions {
+        keys?: string[];
+        tags?: string[];
+    }
+    export class Message implements NativeMessage {
+        value: Buffer;
+        keys?: string[];
+        tags?: string[];
+        constructor(value: Buffer, options?: MessageOptions);
+        static toDrop(): Message;
+    }
     type CallbackFn = (keys: string[], iterator: AsyncIterableIterator<Datum>, metadata: Metadata) => AsyncIterable<Message>;
     /**
      * AsyncServer is a wrapper around a JavaScript callable that will be passed by the user to process the

--- a/index.d.ts
+++ b/index.d.ts
@@ -11,7 +11,7 @@ export declare namespace sourceTransform {
         keys: string[];
         value: Buffer;
         watermark: Date;
-        eventtime: Date;
+        eventTime: Date;
         headers: Record<string, string>;
         userMetadata: UserMetadata | null;
         systemMetadata: SystemMetadata | null;
@@ -24,12 +24,12 @@ export declare namespace sourceTransform {
     }
     export class Message {
         value: Buffer;
-        eventtime: Date;
+        eventTime: Date;
         keys?: string[];
         tags?: string[];
         userMetadata?: UserMetadata;
-        constructor(value: Buffer, eventtime: Date, options?: MessageOptions);
-        static toDrop(eventtime: Date): Message;
+        constructor(value: Buffer, eventTime: Date, options?: MessageOptions);
+        static toDrop(eventTime: Date): Message;
     }
     export class AsyncServer {
         private readonly nativeServer;

--- a/index.d.ts
+++ b/index.d.ts
@@ -113,7 +113,6 @@ export declare namespace batchmap {
     export type Response = binding.batchmap.BatchResponse;
     export const Responses: typeof binding.batchmap.BatchResponses;
     export type Responses = binding.batchmap.BatchResponses;
-    export const Message: typeof binding.batchmap.BatchMessage;
     export type Message = binding.batchmap.BatchMessage;
     export const messageToDrop: typeof binding.batchmap.messageToDrop;
     type BatchMapCallback = (iterator: AsyncIterableIterator<Datum>) => Promise<Response[]>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -43,22 +43,6 @@ export declare namespace accumulator {
     type Datum = binding.accumulator.Datum;
     type Message = binding.accumulator.Message;
     const messageToDrop: typeof binding.accumulator.messageToDrop;
-    type DatumIteratorResult = binding.accumulator.DatumIteratorResult;
-    /**
-     * DatumIterator with added async iterator support
-     */
-    class DatumIterator implements AsyncIterableIterator<Datum> {
-        private readonly nativeDatumIterator;
-        constructor(nativeDatumIterator: binding.accumulator.DatumIterator);
-        /**
-         * Returns the next datum from the stream, or None if the stream has ended
-         */
-        next(): Promise<IteratorResult<Datum>>;
-        /**
-         * Implements async iterator protocol
-         */
-        [Symbol.asyncIterator](): AsyncIterableIterator<Datum>;
-    }
     /**
      * AsyncServer is a wrapper around a JavaScript callable that will be passed by the user to process the
      * data received by the Sink.
@@ -68,7 +52,7 @@ export declare namespace accumulator {
         /**
          * Create a new Sink with the given callback.
          */
-        constructor(accumulatorFn: (datum: DatumIterator) => AsyncIterable<Message>);
+        constructor(accumulatorFn: (datum: AsyncIterableIterator<Datum>) => AsyncIterable<Message>);
         /**
          * Start the AsyncServer server with the given callback
          */
@@ -106,41 +90,25 @@ export declare namespace map {
 }
 export declare namespace sink {
     export type Datum = binding.sink.SinkDatum;
-    type SinkCallback = (iterator: AsyncIterableIterator<Datum>) => Promise<binding.sink.SinkResponse[]>;
-    class SinkAsyncServerImpl {
-        private readonly nativeServer;
-        constructor(sinkFn: SinkCallback);
-        start(socketPath?: string | null, serverInfoPath?: string | null): Promise<void>;
-        stop(): void;
-    }
     export const Response: typeof binding.sink.SinkResponse;
     export type Response = binding.sink.SinkResponse;
     export const Responses: typeof binding.sink.SinkResponses;
     export type Responses = binding.sink.SinkResponses;
     export const Message: typeof binding.sink.SinkMessage;
     export type Message = binding.sink.SinkMessage;
+    type SinkCallback = (iterator: AsyncIterableIterator<Datum>) => Promise<Response[]>;
+    class SinkAsyncServerImpl {
+        private readonly nativeServer;
+        constructor(sinkFn: SinkCallback);
+        start(socketPath?: string | null, serverInfoPath?: string | null): Promise<void>;
+        stop(): void;
+    }
     export const AsyncServer: typeof SinkAsyncServerImpl;
     export type AsyncServer = SinkAsyncServerImpl;
     export {};
 }
 export declare namespace batchmap {
-    type BatchDatum = binding.batchmap.BatchDatum;
-    type BatchDatumIteratorNative = binding.batchmap.BatchDatumIterator;
-    type BatchMapCallback = (iterator: BatchDatumIteratorImpl) => Promise<binding.batchmap.BatchResponse[]>;
-    class BatchDatumIteratorImpl implements AsyncIterableIterator<BatchDatum> {
-        private readonly nativeIterator;
-        constructor(nativeIterator: BatchDatumIteratorNative);
-        next(): Promise<IteratorResult<BatchDatum>>;
-        [Symbol.asyncIterator](): AsyncIterableIterator<BatchDatum>;
-    }
-    class BatchMapAsyncServerImpl {
-        private readonly nativeServer;
-        constructor(batchmapFn: BatchMapCallback);
-        start(socketPath?: string | null, serverInfoPath?: string | null): Promise<void>;
-        stop(): void;
-    }
     export type Datum = binding.batchmap.BatchDatum;
-    export type DatumIteratorResult = binding.batchmap.BatchDatumIteratorResult;
     export const Response: typeof binding.batchmap.BatchResponse;
     export type Response = binding.batchmap.BatchResponse;
     export const Responses: typeof binding.batchmap.BatchResponses;
@@ -148,8 +116,13 @@ export declare namespace batchmap {
     export const Message: typeof binding.batchmap.BatchMessage;
     export type Message = binding.batchmap.BatchMessage;
     export const messageToDrop: typeof binding.batchmap.messageToDrop;
-    export const DatumIterator: typeof BatchDatumIteratorImpl;
-    export type DatumIterator = BatchDatumIteratorImpl;
+    type BatchMapCallback = (iterator: AsyncIterableIterator<Datum>) => Promise<Response[]>;
+    class BatchMapAsyncServerImpl {
+        private readonly nativeServer;
+        constructor(batchmapFn: BatchMapCallback);
+        start(socketPath?: string | null, serverInfoPath?: string | null): Promise<void>;
+        stop(): void;
+    }
     export const AsyncServer: typeof BatchMapAsyncServerImpl;
     export type AsyncServer = BatchMapAsyncServerImpl;
     export {};
@@ -179,7 +152,6 @@ export declare namespace reduce {
     export type Metadata = binding.reduce.Metadata;
     export type IntervalWindow = binding.reduce.IntervalWindow;
     export type Message = binding.reduce.Message;
-    export type DatumIteratorResult = binding.reduce.ReduceDatumIteratorResult;
     export const AsyncServer: typeof ReduceAsyncServerImpl;
     export type AsyncServer = ReduceAsyncServerImpl;
     export {};

--- a/index.ts
+++ b/index.ts
@@ -305,6 +305,7 @@ export namespace sink {
 export namespace batchmap {
     export type Datum = binding.batchmap.BatchDatum
     export const Response = binding.batchmap.BatchResponse
+    // Response contains a list of processed messages
     export type Response = binding.batchmap.BatchResponse
     export const Responses = binding.batchmap.BatchResponses
     export type Responses = binding.batchmap.BatchResponses

--- a/index.ts
+++ b/index.ts
@@ -71,7 +71,7 @@ export namespace sourceTransform {
         return nativeMetadata
     }
 
-    export class SourceTransformAsyncServer {
+    export class AsyncServer {
         private readonly nativeServer: binding.sourceTransform.SourceTransformAsyncServer
 
         constructor(sourceTransformFn: (message: Datum) => Promise<Message[]>) {
@@ -137,10 +137,10 @@ export namespace accumulator {
     }
 
     /**
-     * AccumulatorAsyncServer is a wrapper around a JavaScript callable that will be passed by the user to process the
+     * AsyncServer is a wrapper around a JavaScript callable that will be passed by the user to process the
      * data received by the Sink.
      */
-    export class AccumulatorAsyncServer {
+    export class AsyncServer {
         private readonly nativeServer: binding.accumulator.AccumulatorAsyncServer
         /**
          * Create a new Sink with the given callback.
@@ -165,14 +165,14 @@ export namespace accumulator {
         }
 
         /**
-         * Start the AccumulatorAsyncServer server with the given callback
+         * Start the AsyncServer server with the given callback
          */
         async start(socketPath?: string | null, serverInfoPath?: string | null): Promise<void> {
             return await this.nativeServer.start(socketPath, serverInfoPath)
         }
 
         /**
-         * Stop the AccumulatorAsyncServer server
+         * Stop the AsyncServer server
          */
         stop() {
             return this.nativeServer.stop()
@@ -221,7 +221,7 @@ export namespace map {
         return nativeMetadata
     }
 
-    export class MapServer {
+    export class AsyncServer {
         private readonly nativeServer: binding.map.MapAsyncServer
 
         constructor(mapFn: (message: Datum) => Promise<Message[]>) {
@@ -298,8 +298,8 @@ export namespace sink {
     export type Responses = binding.sink.SinkResponses
     export const Message = binding.sink.SinkMessage
     export type Message = binding.sink.SinkMessage
-    export const SinkAsyncServer = SinkAsyncServerImpl
-    export type SinkAsyncServer = SinkAsyncServerImpl
+    export const AsyncServer = SinkAsyncServerImpl
+    export type AsyncServer = SinkAsyncServerImpl
 }
 
 export namespace batchmap {
@@ -355,8 +355,8 @@ export namespace batchmap {
     export const messageToDrop = binding.batchmap.messageToDrop
     export const DatumIterator = BatchDatumIteratorImpl
     export type DatumIterator = BatchDatumIteratorImpl
-    export const BatchMapAsyncServer = BatchMapAsyncServerImpl
-    export type BatchMapAsyncServer = BatchMapAsyncServerImpl
+    export const AsyncServer = BatchMapAsyncServerImpl
+    export type AsyncServer = BatchMapAsyncServerImpl
 }
 
 export namespace mapstream {
@@ -366,7 +366,7 @@ export namespace mapstream {
 
     export const messageToDrop = binding.mapstream.messageToDrop
 
-    export class MapStreamAsyncServer {
+    export class AsyncServer {
         private readonly mapper: binding.mapstream.MapStreamAsyncServer
 
         constructor(mapFn: MapStreamCallback) {
@@ -446,8 +446,8 @@ export namespace reduce {
     export type IntervalWindow = binding.reduce.IntervalWindow
     export type Message = binding.reduce.Message
     export type DatumIteratorResult = binding.reduce.ReduceDatumIteratorResult
-    export const ReduceAsyncServer = ReduceAsyncServerImpl
-    export type ReduceAsyncServer = ReduceAsyncServerImpl
+    export const AsyncServer = ReduceAsyncServerImpl
+    export type AsyncServer = ReduceAsyncServerImpl
 }
 
 export namespace sessionReduce {
@@ -496,13 +496,13 @@ export namespace sessionReduce {
     }
 
     /**
-     * SessionReduceAsyncServer is a wrapper around a JavaScript callable that will be passed by the user to process the
+     * AsyncServer is a wrapper around a JavaScript callable that will be passed by the user to process the
      * data received by the SessionReduce.
      */
-    export class SessionReduceAsyncServer {
+    export class AsyncServer {
         private readonly nativeServer: binding.sessionReduce.SessionReduceAsyncServer
         /**
-         * Create a new SessionReduceAsyncServer with the given callback.
+         * Create a new AsyncServer with the given callback.
          */
         constructor(sessionReducerImpl: SessionReducer) {
             const wrapperSessionReduceFnCallback = (callbackArgs: SessionReduceCallbackArgs) => {
@@ -530,14 +530,14 @@ export namespace sessionReduce {
         }
 
         /**
-         * Start the SessionReduceAsyncServer server with the given callback
+         * Start the AsyncServer server with the given callback
          */
         async start(socketPath?: string | null, serverInfoPath?: string | null): Promise<void> {
             return await this.nativeServer.start(socketPath, serverInfoPath)
         }
 
         /**
-         * Stop the SessionReduceAsyncServer server
+         * Stop the AsyncServer server
          */
         stop() {
             return this.nativeServer.stop()
@@ -588,13 +588,13 @@ export namespace reduceStream {
     }
 
     /**
-     * SessionReduceAsyncServer is a wrapper around a JavaScript callable that will be passed by the user to process the
+     * AsyncServer is a wrapper around a JavaScript callable that will be passed by the user to process the
      * data received by the SessionReduce.
      */
-    export class ReduceStreamAsyncServer {
+    export class AsyncServer {
         private readonly nativeServer: binding.reduceStream.ReduceStreamAsyncServer
         /**
-         * Create a new ReduceStreamAsyncServer with the given callback.
+         * Create a new AsyncServer with the given callback.
          */
         constructor(callbackFn: CallbackFn) {
             const wrapperCallbackFn = (callbackArgs: CallbackArgs) => {
@@ -618,14 +618,14 @@ export namespace reduceStream {
         }
 
         /**
-         * Start the ReduceStreamAsyncServer server with the given callback
+         * Start the AsyncServer server with the given callback
          */
         async start(socketPath?: string | null, serverInfoPath?: string | null): Promise<void> {
             return await this.nativeServer.start(socketPath, serverInfoPath)
         }
 
         /**
-         * Stop the ReduceStreamAsyncServer server
+         * Stop the AsyncServer server
          */
         stop() {
             return this.nativeServer.stop()
@@ -683,7 +683,7 @@ export namespace source {
         return nativeMetadata
     }
 
-    export class SourceAsyncServer {
+    export class AsyncServer {
         private readonly nativeServer: binding.source.SourceAsyncServer
 
         constructor(sourcer: Sourcer) {

--- a/index.ts
+++ b/index.ts
@@ -77,7 +77,7 @@ export namespace sourceTransform {
         constructor(sourceTransformFn: (message: Datum) => Promise<Message[]>) {
             const wrappedCallback = async (datum: NativeDatum) => {
                 let messages = await sourceTransformFn(new Datum(datum))
-                let nativeMessages = messages.map((message: Message): NativeMessage => {
+                return messages.map((message: Message): NativeMessage => {
                     return {
                         value: message.value,
                         keys: message.keys,
@@ -86,7 +86,6 @@ export namespace sourceTransform {
                         userMetadata: message.userMetadata ? toNativeMetadata(message.userMetadata) : undefined,
                     } satisfies NativeMessage
                 })
-                return nativeMessages
             }
             this.nativeServer = new binding.sourceTransform.SourceTransformAsyncServer(wrappedCallback)
         }
@@ -226,7 +225,7 @@ export namespace map {
         constructor(mapFn: (message: Datum) => Promise<Message[]>) {
             const wrappedCallback = async (datum: Datum): Promise<NativeMessage[]> => {
                 let messages = await mapFn(datum)
-                let nativeMessages = messages.map((message) => {
+                return messages.map((message): NativeMessage => {
                     return {
                         value: message.value,
                         keys: message.keys,
@@ -234,7 +233,6 @@ export namespace map {
                         userMetadata: message.userMetadata ? toNativeMetadata(message.userMetadata) : undefined,
                     } satisfies NativeMessage
                 })
-                return nativeMessages
             }
             this.nativeServer = new binding.map.MapAsyncServer(wrappedCallback)
         }

--- a/index.ts
+++ b/index.ts
@@ -18,7 +18,7 @@ export namespace sourceTransform {
         keys: string[]
         value: Buffer
         watermark: Date
-        eventtime: Date
+        eventTime: Date
         headers: Record<string, string>
         userMetadata: UserMetadata | null
         systemMetadata: SystemMetadata | null
@@ -27,7 +27,7 @@ export namespace sourceTransform {
             this.keys = sourceTransformDatum.keys
             this.value = sourceTransformDatum.value
             this.watermark = sourceTransformDatum.watermark
-            this.eventtime = sourceTransformDatum.eventtime
+            this.eventTime = sourceTransformDatum.eventTime
             this.headers = sourceTransformDatum.headers
             this.userMetadata = sourceTransformDatum.userMetadata
             this.systemMetadata = sourceTransformDatum.systemMetadata
@@ -42,21 +42,21 @@ export namespace sourceTransform {
 
     export class Message {
         value: Buffer
-        eventtime: Date
+        eventTime: Date
         keys?: string[]
         tags?: string[]
         userMetadata?: UserMetadata
 
-        constructor(value: Buffer, eventtime: Date, options?: MessageOptions) {
+        constructor(value: Buffer, eventTime: Date, options?: MessageOptions) {
             this.value = value
-            this.eventtime = eventtime
+            this.eventTime = eventTime
             this.keys = options?.keys
             this.tags = options?.tags
             this.userMetadata = options?.userMetadata
         }
 
-        public static toDrop(eventtime: Date): Message {
-            return new Message(Buffer.from([]), eventtime, { tags: [DROP] })
+        public static toDrop(eventTime: Date): Message {
+            return new Message(Buffer.from([]), eventTime, { tags: [DROP] })
         }
     }
 
@@ -82,7 +82,7 @@ export namespace sourceTransform {
                         value: message.value,
                         keys: message.keys,
                         tags: message.tags,
-                        eventtime: message.eventtime,
+                        eventTime: message.eventTime,
                         userMetadata: message.userMetadata ? toNativeMetadata(message.userMetadata) : undefined,
                     } satisfies NativeMessage
                 })

--- a/index.ts
+++ b/index.ts
@@ -307,7 +307,6 @@ export namespace batchmap {
     export type Response = binding.batchmap.BatchResponse
     export const Responses = binding.batchmap.BatchResponses
     export type Responses = binding.batchmap.BatchResponses
-    export const Message = binding.batchmap.BatchMessage
     export type Message = binding.batchmap.BatchMessage
     export const messageToDrop = binding.batchmap.messageToDrop
 

--- a/src/accumulator.rs
+++ b/src/accumulator.rs
@@ -10,7 +10,6 @@ use std::sync::{Arc, Mutex};
 use tokio::sync::mpsc::{Receiver, Sender};
 
 /// A message to be sent to the next vertex from an accumulator handler.
-//#[derive(Clone, Debug)]
 #[napi(object, namespace = "accumulator")]
 pub struct Message {
     /// Keys are a collection of strings which will be passed on to the next vertex as is. It can
@@ -54,7 +53,7 @@ fn from_datum(
 ) -> Message {
     Message {
         keys: keys.or_else(|| Some(datum.keys.clone())),
-        value: value.unwrap_or_else(|| datum.value),
+        value: value.unwrap_or(datum.value),
         tags,
         id: datum.id.clone(),
         headers: datum.headers.clone(),

--- a/src/batchmap.rs
+++ b/src/batchmap.rs
@@ -137,6 +137,16 @@ impl BatchResponse {
     }
 }
 
+impl From<BatchResponse> for batchmap::BatchResponse {
+    fn from(value: BatchResponse) -> Self {
+        let mut resp = batchmap::BatchResponse::from_id(value.id);
+        for m in value.messages.into_iter() {
+            resp.append(m.clone().into());
+        }
+        resp
+    }
+}
+
 /// A collection of BatchResponse objects for a batch.
 #[derive(Clone, Default, Debug)]
 #[napi(namespace = "batchmap")]
@@ -155,16 +165,6 @@ impl BatchResponses {
     #[napi]
     pub fn append(&mut self, response: &'static BatchResponse) {
         self.responses.push(response);
-    }
-}
-
-impl From<BatchResponse> for batchmap::BatchResponse {
-    fn from(value: BatchResponse) -> Self {
-        let mut resp = batchmap::BatchResponse::from_id(value.id);
-        for m in value.messages.into_iter() {
-            resp.append(m.clone().into());
-        }
-        resp
     }
 }
 

--- a/src/batchmap.rs
+++ b/src/batchmap.rs
@@ -8,14 +8,14 @@ use numaflow::shared::ServerExtras;
 use std::sync::Arc;
 use std::{collections::HashMap, sync::Mutex};
 
-#[derive(Clone, Default, Debug)]
-#[napi(namespace = "batchmap")]
+#[derive(Default)]
+#[napi(object, namespace = "batchmap")]
 pub struct BatchMessage {
     /// Keys are a collection of strings which will be passed on to the next vertex as is. It can
     /// be an empty collection.
     pub keys: Option<Vec<String>>,
     /// Value is the value passed to the next vertex.
-    pub value: Vec<u8>,
+    pub value: Buffer,
     /// Tags are used for [conditional forwarding](https://numaflow.numaproj.io/user-guide/reference/conditional-forwarding/).
     pub tags: Option<Vec<String>>,
 }
@@ -24,32 +24,8 @@ pub struct BatchMessage {
 pub fn message_to_drop() -> BatchMessage {
     BatchMessage {
         keys: None,
-        value: vec![],
+        value: vec![].into(),
         tags: Some(vec![numaflow::shared::DROP.to_string()]),
-    }
-}
-
-#[napi(namespace = "batchmap")]
-impl BatchMessage {
-    #[napi(constructor)]
-    pub fn new(value: Buffer) -> Self {
-        Self {
-            keys: None,
-            value: value.into(),
-            tags: None,
-        }
-    }
-
-    #[napi]
-    pub fn with_keys(&mut self, keys: Vec<String>) -> Self {
-        self.keys = Some(keys);
-        self.clone()
-    }
-
-    #[napi]
-    pub fn with_tags(&mut self, tags: Vec<String>) -> Self {
-        self.tags = Some(tags);
-        self.clone()
     }
 }
 
@@ -57,8 +33,18 @@ impl From<BatchMessage> for batchmap::Message {
     fn from(value: BatchMessage) -> Self {
         Self {
             keys: value.keys,
-            value: value.value,
+            value: value.value.into(),
             tags: value.tags,
+        }
+    }
+}
+
+impl From<&BatchMessage> for batchmap::Message {
+    fn from(value: &BatchMessage) -> Self {
+        Self {
+            keys: value.keys.clone(),
+            value: value.value.iter().map(|b| b.clone()).collect(),
+            tags: value.tags.clone(),
         }
     }
 }
@@ -106,11 +92,11 @@ impl From<batchmap::Datum> for BatchDatum {
     }
 }
 
-#[derive(Clone, Default, Debug)]
+#[derive(Default)]
 #[napi(namespace = "batchmap")]
 pub struct BatchResponse {
     id: String,
-    messages: Vec<&'static BatchMessage>,
+    messages: Vec<BatchMessage>,
 }
 
 #[napi(namespace = "batchmap")]
@@ -132,7 +118,7 @@ impl BatchResponse {
     }
 
     #[napi]
-    pub fn append(&mut self, message: &'static BatchMessage) {
+    pub fn append(&mut self, message: BatchMessage) {
         self.messages.push(message);
     }
 }
@@ -141,14 +127,24 @@ impl From<BatchResponse> for batchmap::BatchResponse {
     fn from(value: BatchResponse) -> Self {
         let mut resp = batchmap::BatchResponse::from_id(value.id);
         for m in value.messages.into_iter() {
-            resp.append(m.clone().into());
+            resp.append(m.into());
+        }
+        resp
+    }
+}
+
+impl From<&BatchResponse> for batchmap::BatchResponse {
+    fn from(value: &BatchResponse) -> Self {
+        let mut resp = batchmap::BatchResponse::from_id(value.id.clone());
+        for m in value.messages.iter() {
+            resp.append(m.into());
         }
         resp
     }
 }
 
 /// A collection of BatchResponse objects for a batch.
-#[derive(Clone, Default, Debug)]
+#[derive(Clone, Default)]
 #[napi(namespace = "batchmap")]
 pub struct BatchResponses {
     pub(crate) responses: Vec<&'static BatchResponse>,
@@ -276,10 +272,7 @@ impl batchmap::BatchMapper for BatchMapper {
         // Call the JavaScript callback
         match self.batchmap_fn.call_async(requests).await {
             Ok(promise) => match promise.await {
-                Ok(responses) => responses
-                    .into_iter()
-                    .map(|resp| resp.clone().into())
-                    .collect(),
+                Ok(responses) => responses.into_iter().map(|resp| resp.into()).collect(),
                 Err(e) => {
                     eprintln!("Error executing JS batchmap function: {:?}", e);
                     vec![]

--- a/src/batchmap.rs
+++ b/src/batchmap.rs
@@ -43,7 +43,7 @@ impl From<&BatchMessage> for batchmap::Message {
     fn from(value: &BatchMessage) -> Self {
         Self {
             keys: value.keys.clone(),
-            value: value.value.iter().map(|b| b.clone()).collect(),
+            value: value.value.iter().copied().collect(),
             tags: value.tags.clone(),
         }
     }

--- a/src/batchmap.rs
+++ b/src/batchmap.rs
@@ -73,7 +73,7 @@ pub struct BatchDatum {
     /// guarantee that we will not see an element older than this time.
     pub watermark: DateTime<Utc>,
     /// Time of the element as seen at source or aligned after a reduce operation.
-    pub eventtime: DateTime<Utc>,
+    pub event_time: DateTime<Utc>,
     /// ID is the unique id of the message
     pub id: String,
     /// Headers for the message.
@@ -86,7 +86,7 @@ impl Clone for BatchDatum {
             keys: self.keys.clone(),
             value: Buffer::from(self.value.to_vec()),
             watermark: self.watermark,
-            eventtime: self.eventtime,
+            event_time: self.event_time,
             id: self.id.clone(),
             headers: self.headers.clone(),
         }
@@ -99,7 +99,7 @@ impl From<batchmap::Datum> for BatchDatum {
             keys: value.keys,
             value: value.value.into(),
             watermark: value.watermark,
-            eventtime: value.event_time,
+            event_time: value.event_time,
             id: value.id,
             headers: value.headers,
         }

--- a/src/map.rs
+++ b/src/map.rs
@@ -105,7 +105,7 @@ impl Datum {
     #[napi(constructor)]
     pub fn new(
         keys: Vec<String>,
-        value: Vec<u8>,
+        value: Buffer,
         watermark: DateTime<Utc>,
         event_time: DateTime<Utc>,
         headers: HashMap<String, String>,
@@ -114,7 +114,7 @@ impl Datum {
     ) -> Self {
         Self {
             keys,
-            value,
+            value: value.into(),
             watermark,
             event_time,
             headers,

--- a/src/map.rs
+++ b/src/map.rs
@@ -91,7 +91,7 @@ pub struct Datum {
     /// guarantee that we will not see an element older than this time.
     watermark: DateTime<Utc>,
     /// Time of the element as seen at source or aligned after a reduce operation.
-    eventtime: DateTime<Utc>,
+    event_time: DateTime<Utc>,
     /// Headers for the message.
     headers: HashMap<String, String>,
     /// User metadata for the message.
@@ -107,7 +107,7 @@ impl Datum {
         keys: Vec<String>,
         value: Vec<u8>,
         watermark: DateTime<Utc>,
-        eventtime: DateTime<Utc>,
+        event_time: DateTime<Utc>,
         headers: HashMap<String, String>,
         user_metadata: Option<&UserMetadata>,
         system_metadata: Option<&SystemMetadata>,
@@ -116,7 +116,7 @@ impl Datum {
             keys,
             value,
             watermark,
-            eventtime,
+            event_time,
             headers,
             user_metadata: user_metadata.map(|metadata| UserMetadata(metadata.0.clone())),
             system_metadata: system_metadata.map(|metadata| SystemMetadata(metadata.0.clone())),
@@ -134,8 +134,8 @@ impl Datum {
     }
 
     #[napi(getter)]
-    pub fn get_eventtime(&self) -> DateTime<Utc> {
-        self.eventtime
+    pub fn get_event_time(&self) -> DateTime<Utc> {
+        self.event_time
     }
 
     #[napi(getter)]
@@ -165,7 +165,7 @@ impl From<map::MapRequest> for Datum {
             keys: value.keys,
             value: value.value.into(),
             watermark: value.watermark,
-            eventtime: value.eventtime,
+            event_time: value.eventtime,
             headers: value.headers,
             user_metadata: Some(UserMetadata(value.user_metadata)),
             system_metadata: Some(SystemMetadata(value.system_metadata)),

--- a/src/map.rs
+++ b/src/map.rs
@@ -163,7 +163,7 @@ impl From<map::MapRequest> for Datum {
     fn from(value: map::MapRequest) -> Self {
         Self {
             keys: value.keys,
-            value: value.value.into(),
+            value: value.value,
             watermark: value.watermark,
             event_time: value.eventtime,
             headers: value.headers,
@@ -202,7 +202,7 @@ impl From<Message> for map::Message {
             keys: value.keys,
             value: value.value.into(),
             tags: value.tags,
-            user_metadata: user_metadata,
+            user_metadata,
         }
     }
 }

--- a/src/mapstream.rs
+++ b/src/mapstream.rs
@@ -40,7 +40,7 @@ pub struct Datum {
     /// guarantee that we will not see an element older than this time.
     pub watermark: DateTime<Utc>,
     /// Time of the element as seen at source or aligned after a reduce operation.
-    pub eventtime: DateTime<Utc>,
+    pub event_time: DateTime<Utc>,
     /// Headers associated with the message.
     pub headers: HashMap<String, String>,
 }
@@ -51,7 +51,7 @@ impl Clone for Datum {
             keys: self.keys.clone(),
             value: Buffer::from(self.value.to_vec()),
             watermark: self.watermark,
-            eventtime: self.eventtime,
+            event_time: self.event_time,
             headers: self.headers.clone(),
         }
     }
@@ -63,7 +63,7 @@ impl From<numaflow::mapstream::MapStreamRequest> for Datum {
             keys: value.keys,
             value: value.value.into(),
             watermark: value.watermark,
-            eventtime: value.eventtime,
+            event_time: value.eventtime,
             headers: value.headers,
         }
     }
@@ -151,7 +151,7 @@ impl mapstream::MapStreamer for JsMapper {
             keys: input.keys,
             value: Buffer::from(input.value.to_vec()),
             watermark: input.watermark,
-            eventtime: input.eventtime,
+            event_time: input.eventtime,
             headers: input.headers,
         };
         match self.map_fn.call_async(datum).await {

--- a/src/session_reduce.rs
+++ b/src/session_reduce.rs
@@ -43,7 +43,7 @@ fn message_to_drop() -> Message {
 #[napi(object, namespace = "sessionReduce")]
 pub struct Datum {
     pub keys: Vec<String>,
-    pub value: Vec<u8>,
+    pub value: Buffer,
     pub watermark: DateTime<Utc>,
     pub event_time: DateTime<Utc>,
     pub headers: HashMap<String, String>,
@@ -59,7 +59,7 @@ impl Datum {
     ) -> Self {
         Self {
             keys,
-            value,
+            value: value.into(),
             watermark,
             event_time,
             headers,

--- a/src/session_reduce.rs
+++ b/src/session_reduce.rs
@@ -45,7 +45,7 @@ pub struct Datum {
     pub keys: Vec<String>,
     pub value: Vec<u8>,
     pub watermark: DateTime<Utc>,
-    pub eventtime: DateTime<Utc>,
+    pub event_time: DateTime<Utc>,
     pub headers: HashMap<String, String>,
 }
 
@@ -54,14 +54,14 @@ impl Datum {
         keys: Vec<String>,
         value: Vec<u8>,
         watermark: DateTime<Utc>,
-        eventtime: DateTime<Utc>,
+        event_time: DateTime<Utc>,
         headers: HashMap<String, String>,
     ) -> Self {
         Self {
             keys,
             value,
             watermark,
-            eventtime,
+            event_time,
             headers,
         }
     }

--- a/src/sink.rs
+++ b/src/sink.rs
@@ -79,7 +79,7 @@ impl SinkMessage {
     #[napi(constructor)]
     pub fn new(value: Buffer, keys: Option<Vec<String>>) -> Self {
         Self {
-            keys: keys,
+            keys,
             value: value.into(),
         }
     }

--- a/src/sink.rs
+++ b/src/sink.rs
@@ -259,7 +259,7 @@ pub struct SinkDatum {
     /// Watermark represented by time (Unix timestamp in milliseconds).
     watermark: DateTime<Utc>,
     /// Event time (Unix timestamp in milliseconds).
-    eventtime: DateTime<Utc>,
+    event_time: DateTime<Utc>,
     /// ID is the unique id of the message to be sent to the Sink.
     pub id: String,
     /// Headers for the message.
@@ -274,7 +274,7 @@ impl From<sink::SinkRequest> for SinkDatum {
             keys: value.keys,
             value: value.value,
             watermark: value.watermark,
-            eventtime: value.event_time,
+            event_time: value.event_time,
             id: value.id,
             headers: value.headers,
             user_metadata: SinkUserMetadata(value.user_metadata),
@@ -297,7 +297,7 @@ impl SinkDatum {
 
     #[napi]
     pub fn get_eventtime(&self) -> DateTime<Utc> {
-        self.eventtime
+        self.event_time
     }
 
     #[napi]

--- a/src/sink.rs
+++ b/src/sink.rs
@@ -178,12 +178,12 @@ impl SinkResponse {
     }
 
     #[napi]
-    pub fn serve(id: String, payload: Vec<u8>) -> Self {
+    pub fn serve(id: String, payload: Buffer) -> Self {
         Self {
             id,
             response_type: ResponseType::Serve,
             err: None,
-            serve_response: Some(payload),
+            serve_response: Some(payload.into()),
             on_success_msg: None,
         }
     }

--- a/src/source_transform.rs
+++ b/src/source_transform.rs
@@ -178,11 +178,7 @@ impl SourceTransformDatum {
 
     #[napi(getter)]
     pub fn get_value(&self) -> Buffer {
-        self.value
-            .iter()
-            .copied()
-            .collect::<Vec<u8>>()
-            .into()
+        self.value.iter().copied().collect::<Vec<u8>>().into()
     }
 
     #[napi(getter)]

--- a/src/source_transform.rs
+++ b/src/source_transform.rs
@@ -92,7 +92,7 @@ pub struct SourceTransformMessage {
     pub value: Buffer,
     /// Time for the given event. This will be used for tracking watermarks. If cannot be derived, set it to the incoming
     /// event_time from the [`SourceTransformRequest`].
-    pub eventtime: DateTime<Utc>,
+    pub event_time: DateTime<Utc>,
     /// Tags are used for [conditional forwarding](https://numaflow.numaproj.io/user-guide/reference/conditional-forwarding/).
     pub tags: Option<Vec<String>>,
     /// User metadata for the message.
@@ -100,11 +100,11 @@ pub struct SourceTransformMessage {
 }
 
 #[napi(namespace = "sourceTransform")]
-pub fn message_to_drop(eventtime: DateTime<Utc>) -> SourceTransformMessage {
+pub fn message_to_drop(event_time: DateTime<Utc>) -> SourceTransformMessage {
     SourceTransformMessage {
         keys: None,
         value: vec![].into(),
-        eventtime,
+        event_time,
         tags: Some(vec![numaflow::shared::DROP.to_string()]),
         user_metadata: None,
     }
@@ -125,7 +125,7 @@ impl From<SourceTransformMessage> for sourcetransform::Message {
         Self {
             keys: value.keys,
             value: value.value.into(),
-            event_time: value.eventtime,
+            event_time: value.event_time,
             tags: value.tags,
             user_metadata,
         }
@@ -142,7 +142,7 @@ pub struct SourceTransformDatum {
     /// guarantee that we will not see an element older than this time.
     watermark: DateTime<Utc>,
     /// Time of the element as seen at source or aligned after a reduce operation.
-    eventtime: DateTime<Utc>,
+    event_time: DateTime<Utc>,
     /// Headers for the message.
     headers: HashMap<String, String>,
     /// User metadata for the message.
@@ -158,7 +158,7 @@ impl SourceTransformDatum {
         keys: Vec<String>,
         value: Buffer,
         watermark: DateTime<Utc>,
-        eventtime: DateTime<Utc>,
+        event_time: DateTime<Utc>,
         headers: HashMap<String, String>,
         user_metadata: Option<&SourceTransformUserMetadata>,
         system_metadata: Option<&SourceTransformSystemMetadata>,
@@ -167,7 +167,7 @@ impl SourceTransformDatum {
             keys,
             value,
             watermark,
-            eventtime,
+            event_time,
             headers,
             user_metadata: user_metadata
                 .map(|metadata| SourceTransformUserMetadata(metadata.0.clone())),
@@ -191,8 +191,8 @@ impl SourceTransformDatum {
     }
 
     #[napi(getter)]
-    pub fn get_eventtime(&self) -> DateTime<Utc> {
-        self.eventtime
+    pub fn get_event_time(&self) -> DateTime<Utc> {
+        self.event_time
     }
 
     #[napi(getter)]
@@ -222,7 +222,7 @@ impl From<sourcetransform::SourceTransformRequest> for SourceTransformDatum {
             keys: value.keys,
             value: value.value.into(),
             watermark: value.watermark,
-            eventtime: value.eventtime,
+            event_time: value.eventtime,
             headers: value.headers,
             user_metadata: Some(SourceTransformUserMetadata(value.user_metadata)),
             system_metadata: Some(SourceTransformSystemMetadata(value.system_metadata)),

--- a/src/source_transform.rs
+++ b/src/source_transform.rs
@@ -180,7 +180,7 @@ impl SourceTransformDatum {
     pub fn get_value(&self) -> Buffer {
         self.value
             .iter()
-            .map(|b| b.clone())
+            .copied()
             .collect::<Vec<u8>>()
             .into()
     }

--- a/tests/__test__/accumulator-server.spec.ts
+++ b/tests/__test__/accumulator-server.spec.ts
@@ -11,7 +11,7 @@ const infoPath = '/tmp/var/run/numaflow/accumulator-info.sock'
 class StreamSorter {
     latest_wm: Date = new Date(-1)
     sorted_buffer: accumulator.Datum[] = []
-    async *streamSorter(datums: accumulator.DatumIterator): AsyncIterable<accumulator.Message> {
+    async *streamSorter(datums: AsyncIterableIterator<accumulator.Datum>): AsyncIterable<accumulator.Message> {
         let datum_count = 0
         for await (let datum of datums) {
             datum_count += 1

--- a/tests/__test__/accumulator-server.spec.ts
+++ b/tests/__test__/accumulator-server.spec.ts
@@ -82,7 +82,7 @@ class StreamSorter {
 test('accumulator integration test', async () => {
     const streamSorter = new StreamSorter()
     // bind streamSorter to streamSorter.streamSorter
-    const server = new accumulator.AccumulatorAsyncServer(streamSorter.streamSorter.bind(streamSorter))
+    const server = new accumulator.AsyncServer(streamSorter.streamSorter.bind(streamSorter))
 
     try {
         // Start the server (non-blocking)

--- a/tests/__test__/batch-map-server.spec.ts
+++ b/tests/__test__/batch-map-server.spec.ts
@@ -9,7 +9,7 @@ const sockPath = '/tmp/var/run/numaflow/batchmap.sock'
 const infoPath = '/tmp/var/run/numaflow/batchmap-info.sock'
 
 test('batchmap integration test', async () => {
-    const server = new batchmap.BatchMapAsyncServer(async (datums): Promise<batchmap.Response[]> => {
+    const server = new batchmap.AsyncServer(async (datums): Promise<batchmap.Response[]> => {
         let responses: batchmap.Response[] = []
         for await (const datum of datums) {
             let response = new batchmap.Response(datum.id)

--- a/tests/__test__/batch-map-server.spec.ts
+++ b/tests/__test__/batch-map-server.spec.ts
@@ -20,7 +20,10 @@ test('batchmap integration test', async () => {
                 if (value.toString() === 'bad') {
                     response.append(batchmap.messageToDrop())
                 } else {
-                    response.append(new batchmap.Message(value).withKeys([key]))
+                    response.append({
+                        value: value,
+                        keys: [key],
+                    })
                 }
 
                 responses.push(response)

--- a/tests/__test__/map-server.spec.ts
+++ b/tests/__test__/map-server.spec.ts
@@ -3,7 +3,7 @@ import { spawn } from 'child_process'
 import { promisify } from 'util'
 
 import { map } from '../../index.js'
-const { MapServer, Message, UserMetadata } = map
+const { AsyncServer, Message, UserMetadata } = map
 
 const sleep = promisify(setTimeout)
 
@@ -35,7 +35,7 @@ test('mapper integration test', async () => {
         return [{ keys: [key], value, userMetadata }]
     }
 
-    const server = new MapServer(mapFn)
+    const server = new AsyncServer(mapFn)
     const sockFile = '/tmp/map.sock'
     const infoFile = '/tmp/map.info'
 

--- a/tests/__test__/mapstream-server.spec.ts
+++ b/tests/__test__/mapstream-server.spec.ts
@@ -18,7 +18,7 @@ test('mapstream server functionlity', async () => {
         }
     }
 
-    const server = new mapstream.MapStreamAsyncServer(mapFn)
+    const server = new mapstream.AsyncServer(mapFn)
 
     const socketPath = '/tmp/mapstream.sock'
     const serverInfoPath = '/tmp/mapstream.info'

--- a/tests/__test__/reduce-server.spec.ts
+++ b/tests/__test__/reduce-server.spec.ts
@@ -9,7 +9,7 @@ const sockPath = '/tmp/var/run/numaflow/reduce.sock'
 const infoPath = '/tmp/var/run/numaflow/reduce-info.sock'
 
 test('reduce integration test', async () => {
-    const server = new reduce.ReduceAsyncServer(async (keys, datums, md) => {
+    const server = new reduce.AsyncServer(async (keys, datums, md) => {
         let counter = 0
         for await (const _ of datums) {
             counter += 1

--- a/tests/__test__/reducestream-server.spec.ts
+++ b/tests/__test__/reducestream-server.spec.ts
@@ -24,7 +24,7 @@ async function* reduceStreamFn(
 }
 
 test('reduce stream integration test', async () => {
-    const server = new reduceStream.ReduceStreamAsyncServer(reduceStreamFn)
+    const server = new reduceStream.AsyncServer(reduceStreamFn)
 
     try {
         // Start the server (non-blocking)

--- a/tests/__test__/session-reduce.spec.ts
+++ b/tests/__test__/session-reduce.spec.ts
@@ -36,7 +36,7 @@ class SessionReduceCounter implements sessionReduce.SessionReducer {
 
 test('session reduce integration test', async () => {
     let sessionReduceCounter = new SessionReduceCounter()
-    const server = new sessionReduce.SessionReduceAsyncServer(sessionReduceCounter)
+    const server = new sessionReduce.AsyncServer(sessionReduceCounter)
 
     try {
         // Start the server (non-blocking)

--- a/tests/__test__/sink-integration.spec.ts
+++ b/tests/__test__/sink-integration.spec.ts
@@ -10,7 +10,7 @@ const sockPath = '/tmp/sink.sock'
 const infoPath = '/tmp/sink-info.sock'
 
 // Start the JavaScript sink server
-const sinker = new sink.AsyncServer(async (datums) => {
+const sinker = new sink.AsyncServer(async (datums: AsyncIterableIterator<sink.Datum>) => {
     const responses: sink.Response[] = []
     for await (const datum of datums) {
         responses.push(sink.Response.ok(datum.id))

--- a/tests/__test__/sink-integration.spec.ts
+++ b/tests/__test__/sink-integration.spec.ts
@@ -10,7 +10,7 @@ const sockPath = '/tmp/sink.sock'
 const infoPath = '/tmp/sink-info.sock'
 
 // Start the JavaScript sink server
-const sinker = new sink.SinkAsyncServer(async (datums) => {
+const sinker = new sink.AsyncServer(async (datums) => {
     const responses: sink.Response[] = []
     for await (const datum of datums) {
         responses.push(sink.Response.ok(datum.id))

--- a/tests/__test__/source-server.spec.ts
+++ b/tests/__test__/source-server.spec.ts
@@ -57,7 +57,7 @@ class Sourcer implements source.Sourcer {
 }
 
 test('source integration test', async () => {
-    const server = new source.SourceAsyncServer(new Sourcer())
+    const server = new source.AsyncServer(new Sourcer())
 
     try {
         // Start the server (non-blocking)

--- a/tests/__test__/source-transform.spec.ts
+++ b/tests/__test__/source-transform.spec.ts
@@ -9,7 +9,7 @@ const sockPath = '/tmp/var/run/numaflow/source-transform.sock'
 const infoPath = '/tmp/var/run/numaflow/source-transform-info.sock'
 
 test('source transform integration test', async () => {
-    const server = new sourceTransform.SourceTransformAsyncServer(async (datum): Promise<sourceTransform.Message[]> => {
+    const server = new sourceTransform.AsyncServer(async (datum): Promise<sourceTransform.Message[]> => {
         return [
             {
                 keys: datum.keys,

--- a/tests/__test__/source-transform.spec.ts
+++ b/tests/__test__/source-transform.spec.ts
@@ -14,7 +14,7 @@ test('source transform integration test', async () => {
             {
                 keys: datum.keys,
                 value: datum.value,
-                eventtime: datum.eventtime,
+                eventTime: datum.eventTime,
                 tags: [],
             },
         ]


### PR DESCRIPTION
- [x] Expose async server as `AsyncServer` instead of `<Component>AsyncServer` ([commit](https://github.com/numaproj/numaflow-js/pull/29/commits/758e30572b8ac72b3405ef28b114977f429db9ad))
- [x] Fix linting in docs ([commit](https://github.com/numaproj/numaflow-js/pull/29/commits/758e30572b8ac72b3405ef28b114977f429db9ad))
- [x] `eventTime` vs `eventtime` ([commit](https://github.com/numaproj/numaflow-js/pull/29/commits/ac304c1787f2d33628578416abeddb346caf804d))
  - Expose it as event_time on Rust FFI side, and eventTime on JS side
- [x] Consistent naming convention for `datum`/`message` ([commit](https://github.com/numaproj/numaflow-js/pull/29/commits/0c4ee38cccbe8729b1f28015fdd388ce6d020ecf))
- [x] Consistent function signatures expected for AsyncServer constructors ([commit](https://github.com/numaproj/numaflow-js/pull/29/commits/0c4ee38cccbe8729b1f28015fdd388ce6d020ecf))
- [x] Consistently use `Buffer` everywhere instead of `Vec<u8>` in some components, which translated to`Array<number>` in JS ([commit1](https://github.com/numaproj/numaflow-js/pull/29/commits/32ec1d4e309f774cec7d724d5ab1dc02515aea13), [commit2](https://github.com/numaproj/numaflow-js/pull/29/commits/d3b871342a2a69ff01b67daa872dfcb1ce247bbd))
- [x] Provide a consistent `toDrop` helper method for `Message` apart from a separate `message_to_drop` function ([commit](https://github.com/numaproj/numaflow-js/pull/29/commits/1f6368c305f0e29808a8f13860434d1a6ab039dc))
  - To do this, I exposed a `Message` class and implemented through it the original Napi `Message`. Exposed the original Napi Message as `NativeMessage`
  - Should `message_to_drop` method not be exposed?
