### PR TITLE
fix: Shutdown transformer server when UDF throws exception

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ tower = "0.5.2"
 hyper-util = "0.1.18"
 prost-types = "0.14.1"
 tokio-stream = "0.1.17"
+tokio-util = "0.7.17"
 
 [package]
 authors = ["Sreekanth", "Vaibhav"]
@@ -40,6 +41,7 @@ chrono.workspace = true
 tokio.workspace = true
 async-trait.workspace = true
 tonic.workspace = true
+tokio-util.workspace = true
 
 [build-dependencies]
 napi-build = "2"

--- a/src/source_transform.rs
+++ b/src/source_transform.rs
@@ -94,7 +94,7 @@ pub struct SourceTransformMessage {
     pub value: Buffer,
     /// Time for the given event. This will be used for tracking watermarks. If cannot be derived, set it to the incoming
     /// event_time from the [`SourceTransformRequest`].
-    pub eventtime: DateTime<Utc>,
+    pub event_time: DateTime<Utc>,
     /// Tags are used for [conditional forwarding](https://numaflow.numaproj.io/user-guide/reference/conditional-forwarding/).
     pub tags: Option<Vec<String>>,
     /// User metadata for the message.
@@ -102,11 +102,11 @@ pub struct SourceTransformMessage {
 }
 
 #[napi(namespace = "sourceTransform")]
-pub fn message_to_drop(eventtime: DateTime<Utc>) -> SourceTransformMessage {
+pub fn message_to_drop(event_time: DateTime<Utc>) -> SourceTransformMessage {
     SourceTransformMessage {
         keys: None,
         value: vec![].into(),
-        eventtime,
+        event_time,
         tags: Some(vec![numaflow::shared::DROP.to_string()]),
         user_metadata: None,
     }
@@ -127,7 +127,7 @@ impl From<SourceTransformMessage> for sourcetransform::Message {
         Self {
             keys: value.keys,
             value: value.value.into(),
-            event_time: value.eventtime,
+            event_time: value.event_time,
             tags: value.tags,
             user_metadata,
         }
@@ -144,7 +144,7 @@ pub struct SourceTransformDatum {
     /// guarantee that we will not see an element older than this time.
     watermark: DateTime<Utc>,
     /// Time of the element as seen at source or aligned after a reduce operation.
-    eventtime: DateTime<Utc>,
+    event_time: DateTime<Utc>,
     /// Headers for the message.
     headers: HashMap<String, String>,
     /// User metadata for the message.
@@ -160,7 +160,7 @@ impl SourceTransformDatum {
         keys: Vec<String>,
         value: Buffer,
         watermark: DateTime<Utc>,
-        eventtime: DateTime<Utc>,
+        event_time: DateTime<Utc>,
         headers: HashMap<String, String>,
         user_metadata: Option<&SourceTransformUserMetadata>,
         system_metadata: Option<&SourceTransformSystemMetadata>,
@@ -169,7 +169,7 @@ impl SourceTransformDatum {
             keys,
             value,
             watermark,
-            eventtime,
+            event_time,
             headers,
             user_metadata: user_metadata
                 .map(|metadata| SourceTransformUserMetadata(metadata.0.clone())),
@@ -180,7 +180,7 @@ impl SourceTransformDatum {
 
     #[napi(getter)]
     pub fn get_value(&self) -> Buffer {
-        self.value.iter().cloned().collect::<Vec<u8>>().into()
+        self.value.iter().copied().collect::<Vec<u8>>().into()
     }
 
     #[napi(getter)]
@@ -189,8 +189,8 @@ impl SourceTransformDatum {
     }
 
     #[napi(getter)]
-    pub fn get_eventtime(&self) -> DateTime<Utc> {
-        self.eventtime
+    pub fn get_event_time(&self) -> DateTime<Utc> {
+        self.event_time
     }
 
     #[napi(getter)]
@@ -220,7 +220,7 @@ impl From<sourcetransform::SourceTransformRequest> for SourceTransformDatum {
             keys: value.keys,
             value: value.value.into(),
             watermark: value.watermark,
-            eventtime: value.eventtime,
+            event_time: value.eventtime,
             headers: value.headers,
             user_metadata: Some(SourceTransformUserMetadata(value.user_metadata)),
             system_metadata: Some(SourceTransformSystemMetadata(value.system_metadata)),


### PR DESCRIPTION
Tested by running a `source-transformer-sink` pipeline, where the `transformer` throws exception every fixed duration (`throw new Error('Simulated crash')`).

transformer:
```log
➜  kubectl logs -f ts-crash-in-0-mofpl -c transformer

Starting source transformer server
2 Minutes since last crash. Simulating crash now
Error awaiting Javascript promise returned by transform function: Error { status: "GenericFailure", reason: "Error: Simulated crash" }
SourceTransformAsyncServer has shutdown...
```

numa:
```log
2025-12-11T03:18:44.458872Z INFO numaflow_core::source: All inflight messages are acked/nacked. Source stopped.
2025-12-11T03:18:44.458962Z ERROR numaflow_core::pipeline::forwarder::source_forwarder: Error while reading messages e=Grpc(Status { code: Internal, message: "UDF_EXECUTION_ERROR(transformer): Error awaiting Javascript promise returned by transform function at src/source_transform.rs:360:21", details: b"\x08\r\x12\x84\x01UDF_EXECUTION_ERROR(transformer): Error awaiting Javascript promise returned by transform function at src/source_transform.rs:360:21\x1a\xb0\x02\n(type.googleapis.com/google.rpc.DebugInfo\x12\x83\x02\x12\x80\x02 0: <unknown>\n 1: <unknown>\n 2: <unknown>\n 3: <unknown>\n 4: <unknown>\n 5: <unknown>\n 6: <unknown>\n 7: <unknown>\n 8: <unknown>\n 9: <unknown>\n 10: <unknown>\n 11: <unknown>\n 12: <unknown>\n 13: <unknown>\n 14: <unknown>\n 15: <unknown>\n", source: None })
2025-12-11T03:18:44.458994Z INFO numaflow_core::metrics: Stopped the Lag-Reader Expose tasks
2025-12-11T03:18:44.459027Z ERROR numaflow_core: Pipeline failed because of UDF failure error=Status { code: Internal, message: "UDF_EXECUTION_ERROR(transformer): Error awaiting Javascript promise returned by transform function at src/source_transform.rs:360:21", details: b"\x08\r\x12\x84\x01UDF_EXECUTION_ERROR(transformer): Error awaiting Javascript promise returned by transform function at src/source_transform.rs:360:21\x1a\xb0\x02\n(type.googleapis.com/google.rpc.DebugInfo\x12\x83\x02\x12\x80\x02 0: <unknown>\n 1: <unknown>\n 2: <unknown>\n 3: <unknown>\n 4: <unknown>\n 5: <unknown>\n 6: <unknown>\n 7: <unknown>\n 8: <unknown>\n 9: <unknown>\n 10: <unknown>\n 11: <unknown>\n 12: <unknown>\n 13: <unknown>\n 14: <unknown>\n 15: <unknown>\n", source: None }
2025-12-11T03:18:44.459350Z INFO numaflow_core: Gracefully Exiting...
2025-12-11T03:18:44.459377Z INFO numaflow: Exited.
```
